### PR TITLE
Compatible with GNOME 46

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -6,7 +6,8 @@
     "url": "https://github.com/dbatis/gnome-shell-extension-audio-switch-shortcuts",
     "settings-schema": "org.gnome.shell.extensions.audio-switch-shortcuts",
     "shell-version": [
-        "48"
+        "48",
+        "46"
     ],
     "gettext-domain": "audio-switch-shortcuts@dbatis.github.com"
 }


### PR DESCRIPTION
Thank you for making this very useful extension!
It runs perfectly fine on GNOME 46 which is what Ubuntu 24.04 LTS is using. 

Also if you are interested, it is possible to show the selected device in the same OSD panel as the volume, see 8df9194f823245945ae70abdff4c3964a615238f instead of creating a notification. 