### PR TITLE
Fix volume OSD support for GNOME 49

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -166,7 +166,15 @@ export default class AudioSwitchShortCutsExtension extends Extension {
 
             const message = alternateName !== undefined ? alternateName : device.name
             const icon = this.mixer?.getIcon(device)
-            Main.osdWindowManager.show(-1, icon, message, null, null)
+
+            // GNOME versions 46+
+            if (typeof Main.osdWindowManager.showAll === 'function') {
+                Main.osdWindowManager.showAll(icon, message, null, null)
+            }
+            // Older GNOME versions
+            else if (typeof Main.osdWindowManager.show === 'function') {
+                Main.osdWindowManager.show(-1, icon, message, null, null)
+            }
 
         }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -167,7 +167,7 @@ export default class AudioSwitchShortCutsExtension extends Extension {
             const message = alternateName !== undefined ? alternateName : device.name
             const icon = this.mixer?.getIcon(device)
 
-            // GNOME versions 46+
+            // GNOME versions 49+
             if (typeof Main.osdWindowManager.showAll === 'function') {
                 Main.osdWindowManager.showAll(icon, message, null, null)
             }


### PR DESCRIPTION
I recently upgraded my system and noticed that the "Use Volume OSD for notifications" feature is no longer working. If the regular "Show Notifications" option is used, notifications work as expected.

I did some digging and it looks like it's related to this:

https://gjs.guide/extensions/upgrading/gnome-shell-49.html#osdwindowmanager

https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/gnome-49/js/ui/osdWindow.js

https://gitlab.gnome.org/GNOME/gnome-shell/-/commit/58e9923478b91b8c8b6b99dba5f8b9566919c9eb

After swapping out the function it works fine. I implemented it with a conditional check to not break compatibility with older GNOME versions.