### PR TITLE
Fix GNOME 50 startup crash

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,16 +1,10 @@
 {
-    "name": "Audio Switch Shortcuts",
-    "description": "This extension allows you to switch speakers and microphones with global keyboard shortcuts, instead of using the mouse to open the Gnome Panel or navigate menus. It allows you to set specific audio devices to cycle through, and set your own hotkeys.",
-    "version-name": "1.0.9",
-    "uuid": "audio-switch-shortcuts@dbatis.github.com",
-    "url": "https://github.com/dbatis/gnome-shell-extension-audio-switch-shortcuts",
-    "settings-schema": "org.gnome.shell.extensions.audio-switch-shortcuts",
-    "shell-version": [
-        "46",
-        "47",
-        "48",
-        "49",
-        "50"
-    ],
-    "gettext-domain": "audio-switch-shortcuts@dbatis.github.com"
+  "name": "Audio Switch Shortcuts",
+  "description": "This extension allows you to switch speakers and microphones with global keyboard shortcuts, instead of using the mouse to open the Gnome Panel or navigate menus. It allows you to set specific audio devices to cycle through, and set your own hotkeys.",
+  "version-name": "1.1.0",
+  "uuid": "audio-switch-shortcuts@dbatis.github.com",
+  "url": "https://github.com/dbatis/gnome-shell-extension-audio-switch-shortcuts",
+  "settings-schema": "org.gnome.shell.extensions.audio-switch-shortcuts",
+  "shell-version": ["46", "47", "48", "49", "50"],
+  "gettext-domain": "audio-switch-shortcuts@dbatis.github.com"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,36 +1,48 @@
 {
   "name": "gnome-shell-extension-audio-switch-shortcuts",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gnome-shell-extension-audio-switch-shortcuts",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "LGPL-3.0-or-later",
       "dependencies": {
-        "@girs/gjs": "^4.0.0-beta.23",
-        "@girs/gnome-shell": "^48.0.2"
+        "@girs/gjs": "^4.1.0",
+        "@girs/gnome-shell": "^50.0.4"
       },
       "devDependencies": {
-        "eslint": "^9.26.0",
-        "eslint-plugin-jsdoc": "^50.6.11",
-        "typescript": "^5.8.3"
+        "eslint": "^10.7.0",
+        "eslint-plugin-jsdoc": "^63.2.0",
+        "typescript": "^6.0.3"
       }
     },
     "node_modules/@es-joy/jsdoccomment": {
-      "version": "0.49.0",
-      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.49.0.tgz",
-      "integrity": "sha512-xjZTSFgECpb9Ohuk5yMX5RhUEbfeQcuOp8IF60e+wyzWEF0M5xeSgqsfLtvPEX8BIyOX9saZqzuGPmZ8oWc+5Q==",
+      "version": "0.88.0",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.88.0.tgz",
+      "integrity": "sha512-GK/HL/claLLNo5KG705auIlZMwEtmn88ofSGuLsmVZwKBqMPJhW9DiznYNq07QEqz9BPtA3LBfYImtZmhVvRAw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "comment-parser": "1.4.1",
-        "esquery": "^1.6.0",
-        "jsdoc-type-pratt-parser": "~4.1.0"
+        "@types/estree": "^1.0.9",
+        "@typescript-eslint/types": "^8.59.4",
+        "comment-parser": "1.4.7",
+        "esquery": "^1.7.0",
+        "jsdoc-type-pratt-parser": "~7.2.0"
       },
       "engines": {
-        "node": ">=16"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@es-joy/resolve.exports": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@es-joy/resolve.exports/-/resolve.exports-1.2.0.tgz",
+      "integrity": "sha512-Q9hjxWI5xBM+qW2enxfe8wDKdFWMfd0Z29k5ZJnuBqD/CasY5Zryj09aCA6owbGATWz+39p5uIdaHXpopOcG8g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -53,9 +65,9 @@
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.12.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
-      "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -63,760 +75,724 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.1.tgz",
-      "integrity": "sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==",
+      "version": "0.23.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
+      "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/object-schema": "^2.1.7",
+        "@eslint/object-schema": "^3.0.5",
         "debug": "^4.3.1",
-        "minimatch": "^3.1.2"
+        "minimatch": "^10.2.4"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
-      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
+      "integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.17.0"
+        "@eslint/core": "^1.2.1"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/core": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
-      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+      "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@types/json-schema": "^7.0.15"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@eslint/eslintrc": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.1.tgz",
-      "integrity": "sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^6.12.4",
-        "debug": "^4.3.2",
-        "espree": "^10.0.1",
-        "globals": "^14.0.0",
-        "ignore": "^5.2.0",
-        "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.0",
-        "minimatch": "^3.1.2",
-        "strip-json-comments": "^3.1.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/@eslint/js": {
-      "version": "9.39.1",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.1.tgz",
-      "integrity": "sha512-S26Stp4zCy88tH94QbBv3XCuzRQiZ9yXofEILmglYTh/Ug/a9/umqvgFtYBAo3Lp0nsI/5/qH1CCrbdK3AP1Tw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://eslint.org/donate"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/object-schema": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
-      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
+      "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
-      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
+      "integrity": "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.17.0",
+        "@eslint/core": "^1.2.1",
         "levn": "^0.4.1"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@girs/accountsservice-1.0": {
-      "version": "1.0.0-4.0.0-beta.23",
-      "resolved": "https://registry.npmjs.org/@girs/accountsservice-1.0/-/accountsservice-1.0-1.0.0-4.0.0-beta.23.tgz",
-      "integrity": "sha512-QR7xfIvNbovmhNzzma+NxIMsQR8zgTaYk16Dqa/4YD8XBWrAgWuQhwEKKibG9KbQe5+YSUDUxJlbkSeOb3S5mg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@girs/accountsservice-1.0/-/accountsservice-1.0-4.1.0.tgz",
+      "integrity": "sha512-Kp8TXbun34nQJ6h0EOqmAJ8P8sd3huzJMPtdw2FOpTPzViFcUPC95fICi231Ur0FhfhH62lXZnHthifUKb01HQ==",
       "license": "MIT",
       "dependencies": {
-        "@girs/gio-2.0": "^2.84.0-4.0.0-beta.23",
-        "@girs/gjs": "^4.0.0-beta.23",
-        "@girs/glib-2.0": "^2.84.0-4.0.0-beta.23",
-        "@girs/gmodule-2.0": "^2.0.0-4.0.0-beta.23",
-        "@girs/gobject-2.0": "^2.84.0-4.0.0-beta.23"
+        "@girs/gio-2.0": "^4.1.0",
+        "@girs/gjs": "^4.1.0",
+        "@girs/glib-2.0": "^4.1.0",
+        "@girs/gmodule-2.0": "^4.1.0",
+        "@girs/gobject-2.0": "^4.1.0"
       }
     },
     "node_modules/@girs/adw-1": {
-      "version": "1.8.0-4.0.0-beta.23",
-      "resolved": "https://registry.npmjs.org/@girs/adw-1/-/adw-1-1.8.0-4.0.0-beta.23.tgz",
-      "integrity": "sha512-yDhOFc7qHTvIXo5naYuljtmpipP+z0JCyw6qw+mGEwyh0PXF9VA7MOUu5lUVQAsJgwUD5hLsWmqhd/JxnaXf7Q==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@girs/adw-1/-/adw-1-4.1.0.tgz",
+      "integrity": "sha512-Xv4doRXq7o9K+plUlrjl7e6ba04jtc7JS6U8JEMGZuNOL0BXsZa2lNbnLKKjUQnwzbh80EDECgyhiBkbhq7Heg==",
       "license": "MIT",
       "dependencies": {
-        "@girs/cairo-1.0": "^1.0.0-4.0.0-beta.23",
-        "@girs/freetype2-2.0": "^2.0.0-4.0.0-beta.23",
-        "@girs/gdk-4.0": "^4.0.0-4.0.0-beta.23",
-        "@girs/gdkpixbuf-2.0": "^2.0.0-4.0.0-beta.23",
-        "@girs/gio-2.0": "^2.84.0-4.0.0-beta.23",
-        "@girs/gjs": "^4.0.0-beta.23",
-        "@girs/glib-2.0": "^2.84.0-4.0.0-beta.23",
-        "@girs/gmodule-2.0": "^2.0.0-4.0.0-beta.23",
-        "@girs/gobject-2.0": "^2.84.0-4.0.0-beta.23",
-        "@girs/graphene-1.0": "^1.0.0-4.0.0-beta.23",
-        "@girs/gsk-4.0": "^4.0.0-4.0.0-beta.23",
-        "@girs/gtk-4.0": "^4.18.3-4.0.0-beta.23",
-        "@girs/harfbuzz-0.0": "^9.0.0-4.0.0-beta.23",
-        "@girs/pango-1.0": "^1.56.4-4.0.0-beta.23",
-        "@girs/pangocairo-1.0": "^1.0.0-4.0.0-beta.23"
+        "@girs/cairo-1.0": "^4.1.0",
+        "@girs/freetype2-2.0": "^4.1.0",
+        "@girs/gdk-4.0": "^4.1.0",
+        "@girs/gdkpixbuf-2.0": "^4.1.0",
+        "@girs/gio-2.0": "^4.1.0",
+        "@girs/gjs": "^4.1.0",
+        "@girs/glib-2.0": "^4.1.0",
+        "@girs/gmodule-2.0": "^4.1.0",
+        "@girs/gobject-2.0": "^4.1.0",
+        "@girs/graphene-1.0": "^4.1.0",
+        "@girs/gsk-4.0": "^4.1.0",
+        "@girs/gtk-4.0": "^4.1.0",
+        "@girs/harfbuzz-0.0": "^4.1.0",
+        "@girs/pango-1.0": "^4.1.0",
+        "@girs/pangocairo-1.0": "^4.1.0"
       }
     },
     "node_modules/@girs/atk-1.0": {
-      "version": "2.56.0-4.0.0-beta.23",
-      "resolved": "https://registry.npmjs.org/@girs/atk-1.0/-/atk-1.0-2.56.0-4.0.0-beta.23.tgz",
-      "integrity": "sha512-5kFs//8rkORYMJh0FQNeNciEQmbMNfA4Jo8AV9du8WiWGAdFzkPLH9o3eQrqRGIqZBsbqiEy3FS+R9P7+bn/UA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@girs/atk-1.0/-/atk-1.0-4.1.0.tgz",
+      "integrity": "sha512-GBf3Ehc56boCbDx9lOt4hMWaETgxsUZ33Bfk022BVHhvWwXd5iWFt9wQHTiFkgJcAJjmPavhkouniAbuuBwH4Q==",
       "license": "MIT",
       "dependencies": {
-        "@girs/gjs": "^4.0.0-beta.23",
-        "@girs/glib-2.0": "^2.84.0-4.0.0-beta.23",
-        "@girs/gobject-2.0": "^2.84.0-4.0.0-beta.23"
+        "@girs/gjs": "^4.1.0",
+        "@girs/glib-2.0": "^4.1.0",
+        "@girs/gobject-2.0": "^4.1.0"
       }
     },
     "node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.0-beta.23",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.0-beta.23.tgz",
-      "integrity": "sha512-t5fADO+9TmZy8Xzk6Fqk23B3bmakzhNQxa3kFERzy2cL8p1q1pAWm1ARNcadIsl2IbflS4Hbn5sAwRwOm8W67A==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-4.1.0.tgz",
+      "integrity": "sha512-iCdRmpCPpQn+skaJfLsDUvSSidKgQLAsFeah5Ac5I5dRmpdwCvDTsox6wreZssfhERWcUAldtWj7wXmSzPBLKg==",
       "license": "MIT",
       "dependencies": {
-        "@girs/gjs": "^4.0.0-beta.23",
-        "@girs/glib-2.0": "^2.84.0-4.0.0-beta.23",
-        "@girs/gobject-2.0": "^2.84.0-4.0.0-beta.23"
+        "@girs/gjs": "^4.1.0",
+        "@girs/glib-2.0": "^4.1.0",
+        "@girs/gobject-2.0": "^4.1.0"
       }
     },
-    "node_modules/@girs/clutter-16": {
-      "version": "16.0.0-4.0.0-beta.23",
-      "resolved": "https://registry.npmjs.org/@girs/clutter-16/-/clutter-16-16.0.0-4.0.0-beta.23.tgz",
-      "integrity": "sha512-dQ0cfxSa4E0AAfsFhs8Yd/eFHv7286c5oo7cku13nlEYBFQpyfUfa+CMSclAbUBUxM35PseXGXEy0jegkKpbXQ==",
+    "node_modules/@girs/clutter-18": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@girs/clutter-18/-/clutter-18-4.1.0.tgz",
+      "integrity": "sha512-1peMQVW/Uu22YoEG8Msx8lRQgOXy1Efuw2al03v6Lc0yWdAXdL8aWZ4d8p6YKAH6WTBmiMthWG60+bZqKur0Cw==",
       "license": "MIT",
       "dependencies": {
-        "@girs/atk-1.0": "^2.56.0-4.0.0-beta.23",
-        "@girs/cairo-1.0": "^1.0.0-4.0.0-beta.23",
-        "@girs/cogl-16": "^16.0.0-4.0.0-beta.23",
-        "@girs/freetype2-2.0": "^2.0.0-4.0.0-beta.23",
-        "@girs/gio-2.0": "^2.84.0-4.0.0-beta.23",
-        "@girs/gjs": "^4.0.0-beta.23",
-        "@girs/gl-1.0": "^1.0.0-4.0.0-beta.23",
-        "@girs/glib-2.0": "^2.84.0-4.0.0-beta.23",
-        "@girs/gmodule-2.0": "^2.0.0-4.0.0-beta.23",
-        "@girs/gobject-2.0": "^2.84.0-4.0.0-beta.23",
-        "@girs/graphene-1.0": "^1.0.0-4.0.0-beta.23",
-        "@girs/harfbuzz-0.0": "^9.0.0-4.0.0-beta.23",
-        "@girs/mtk-16": "^16.0.0-4.0.0-beta.23",
-        "@girs/pango-1.0": "^1.56.4-4.0.0-beta.23",
-        "@girs/xlib-2.0": "^2.0.0-4.0.0-beta.23"
+        "@girs/atk-1.0": "^4.1.0",
+        "@girs/cairo-1.0": "^4.1.0",
+        "@girs/cogl-18": "^4.1.0",
+        "@girs/freetype2-2.0": "^4.1.0",
+        "@girs/gio-2.0": "^4.1.0",
+        "@girs/gjs": "^4.1.0",
+        "@girs/gl-1.0": "^4.1.0",
+        "@girs/glib-2.0": "^4.1.0",
+        "@girs/gmodule-2.0": "^4.1.0",
+        "@girs/gobject-2.0": "^4.1.0",
+        "@girs/graphene-1.0": "^4.1.0",
+        "@girs/harfbuzz-0.0": "^4.1.0",
+        "@girs/mtk-18": "^4.1.0",
+        "@girs/pango-1.0": "^4.1.0"
       }
     },
-    "node_modules/@girs/cogl-16": {
-      "version": "16.0.0-4.0.0-beta.23",
-      "resolved": "https://registry.npmjs.org/@girs/cogl-16/-/cogl-16-16.0.0-4.0.0-beta.23.tgz",
-      "integrity": "sha512-0UxbYg0gk0lcGnAwArY0Gq6ljfpzTUcnlyn1iCVI51nvFTyVCIRk4e89PM30aE/QN0daeFs/4+fjEsYUhHKNjA==",
+    "node_modules/@girs/cogl-18": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@girs/cogl-18/-/cogl-18-4.1.0.tgz",
+      "integrity": "sha512-eykux7piDFKlAoNpuEdzi7FjrD3TbSNlGCUHgKkkV8NEgU0WQr+SH15yCVMJDlqR4cxH8byESOaiXginEBIgEg==",
       "license": "MIT",
       "dependencies": {
-        "@girs/gjs": "^4.0.0-beta.23",
-        "@girs/gl-1.0": "^1.0.0-4.0.0-beta.23",
-        "@girs/glib-2.0": "^2.84.0-4.0.0-beta.23",
-        "@girs/gobject-2.0": "^2.84.0-4.0.0-beta.23",
-        "@girs/graphene-1.0": "^1.0.0-4.0.0-beta.23",
-        "@girs/mtk-16": "^16.0.0-4.0.0-beta.23",
-        "@girs/xlib-2.0": "^2.0.0-4.0.0-beta.23"
-      }
-    },
-    "node_modules/@girs/cogl-2.0": {
-      "version": "2.0.0-4.0.0-beta.23",
-      "resolved": "https://registry.npmjs.org/@girs/cogl-2.0/-/cogl-2.0-2.0.0-4.0.0-beta.23.tgz",
-      "integrity": "sha512-OSFZav9AiarIY5YuTEjOAG1IghHMuz/E+ZroPtuuI4Nhjp5AGVj7OevVw6QOVzhrGY95a3/ZhSP5sSpI8EdWyA==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/gjs": "^4.0.0-beta.23",
-        "@girs/gl-1.0": "^1.0.0-4.0.0-beta.23",
-        "@girs/glib-2.0": "^2.84.0-4.0.0-beta.23",
-        "@girs/gobject-2.0": "^2.84.0-4.0.0-beta.23"
+        "@girs/gjs": "^4.1.0",
+        "@girs/gl-1.0": "^4.1.0",
+        "@girs/glib-2.0": "^4.1.0",
+        "@girs/gobject-2.0": "^4.1.0",
+        "@girs/graphene-1.0": "^4.1.0",
+        "@girs/mtk-18": "^4.1.0"
       }
     },
     "node_modules/@girs/freetype2-2.0": {
-      "version": "2.0.0-4.0.0-beta.23",
-      "resolved": "https://registry.npmjs.org/@girs/freetype2-2.0/-/freetype2-2.0-2.0.0-4.0.0-beta.23.tgz",
-      "integrity": "sha512-DpMJET2s2ZXmGjScv+tu8tyEDIT6mIEWgY/Lp5HaXTUkKpw+LdtVV0bEwiXMYn3TSs6QYJZyBxNlwTSD3qb+Ww==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@girs/freetype2-2.0/-/freetype2-2.0-4.1.0.tgz",
+      "integrity": "sha512-/+fMzCY84TrKi5wcT/EVQulM9xPhCAA5cTaZclzufA01MvasA8vrPu5zEF8qhfYbm77ro94A8P6kWpcOf1LxEQ==",
       "license": "MIT",
       "dependencies": {
-        "@girs/gjs": "^4.0.0-beta.23",
-        "@girs/gobject-2.0": "^2.84.0-4.0.0-beta.23"
+        "@girs/gjs": "^4.1.0",
+        "@girs/gobject-2.0": "^4.1.0"
       }
     },
     "node_modules/@girs/gck-2": {
-      "version": "4.4.0-4.0.0-beta.23",
-      "resolved": "https://registry.npmjs.org/@girs/gck-2/-/gck-2-4.4.0-4.0.0-beta.23.tgz",
-      "integrity": "sha512-PY1yLymRxNDnUMrLAvu6dAImoUco4RpkFv+u72AUGXcgbmvPNcRwBC/11TcLHlqnzOzy31QjWZBYsbUE89jWiA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@girs/gck-2/-/gck-2-4.1.0.tgz",
+      "integrity": "sha512-jrFH1iWhkGxFG2jCS+NYzWBM6jcaNYNysA3r9AT+EWmY7kVkMeGi9ec+LSqIqjC0qU/MaHaLIZ6HU6o34zZU3Q==",
       "license": "MIT",
       "dependencies": {
-        "@girs/gio-2.0": "^2.84.0-4.0.0-beta.23",
-        "@girs/gjs": "^4.0.0-beta.23",
-        "@girs/glib-2.0": "^2.84.0-4.0.0-beta.23",
-        "@girs/gmodule-2.0": "^2.0.0-4.0.0-beta.23",
-        "@girs/gobject-2.0": "^2.84.0-4.0.0-beta.23"
+        "@girs/gio-2.0": "^4.1.0",
+        "@girs/gjs": "^4.1.0",
+        "@girs/glib-2.0": "^4.1.0",
+        "@girs/gmodule-2.0": "^4.1.0",
+        "@girs/gobject-2.0": "^4.1.0"
       }
     },
     "node_modules/@girs/gcr-4": {
-      "version": "4.4.0-4.0.0-beta.23",
-      "resolved": "https://registry.npmjs.org/@girs/gcr-4/-/gcr-4-4.4.0-4.0.0-beta.23.tgz",
-      "integrity": "sha512-Oo6/wDbbAq+ytfFGhOHFjOjfVdhTkE0EvdvTLSa31qNfCEI+0I0OwL1gG35DoUCKeESqd6WgpqMXmMnop3/yIg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@girs/gcr-4/-/gcr-4-4.1.0.tgz",
+      "integrity": "sha512-gpwN7hDZDg7ZFvVKhQcRIm5BhmcprFigtn6NR5Kohsquc6YGiq70v9Xo19gmWRQMFMo3nB+mZAAjzvTbpXhCww==",
       "license": "MIT",
       "dependencies": {
-        "@girs/gck-2": "^4.4.0-4.0.0-beta.23",
-        "@girs/gio-2.0": "^2.84.0-4.0.0-beta.23",
-        "@girs/gjs": "^4.0.0-beta.23",
-        "@girs/glib-2.0": "^2.84.0-4.0.0-beta.23",
-        "@girs/gmodule-2.0": "^2.0.0-4.0.0-beta.23",
-        "@girs/gobject-2.0": "^2.84.0-4.0.0-beta.23"
+        "@girs/gck-2": "^4.1.0",
+        "@girs/gio-2.0": "^4.1.0",
+        "@girs/gjs": "^4.1.0",
+        "@girs/glib-2.0": "^4.1.0",
+        "@girs/gmodule-2.0": "^4.1.0",
+        "@girs/gobject-2.0": "^4.1.0"
       }
     },
     "node_modules/@girs/gdesktopenums-3.0": {
-      "version": "3.0.0-4.0.0-beta.23",
-      "resolved": "https://registry.npmjs.org/@girs/gdesktopenums-3.0/-/gdesktopenums-3.0-3.0.0-4.0.0-beta.23.tgz",
-      "integrity": "sha512-T2LpS68w/HtOH1Cd/RGWOXrqPJEsUNOhUOpjwZhH6lu3Ey1IYEq5yyyIeWi3ts9QS4SjbhZvqMTJKFwA5xywMw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@girs/gdesktopenums-3.0/-/gdesktopenums-3.0-4.1.0.tgz",
+      "integrity": "sha512-itkzeTHIezAVpuQgqDPKPPt00KOUZRPPdQBU4Ac/4/nKZTcmKwPFfLgQjgkcX1V4UQYknvGFoEY2E8X2tJagiQ==",
       "license": "MIT",
       "dependencies": {
-        "@girs/gjs": "^4.0.0-beta.23",
-        "@girs/gobject-2.0": "^2.84.0-4.0.0-beta.23"
+        "@girs/gjs": "^4.1.0",
+        "@girs/gobject-2.0": "^4.1.0"
       }
     },
     "node_modules/@girs/gdk-4.0": {
-      "version": "4.0.0-4.0.0-beta.23",
-      "resolved": "https://registry.npmjs.org/@girs/gdk-4.0/-/gdk-4.0-4.0.0-4.0.0-beta.23.tgz",
-      "integrity": "sha512-esdIxWgxyKQKYAsQBnTZPHocf5CXwEovt6Xp2aIVxbATLzzd0x35194PPjq51IbZ7eRi/XnBC9yTlNI5JYVNog==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@girs/gdk-4.0/-/gdk-4.0-4.1.0.tgz",
+      "integrity": "sha512-Wf7ZaDS2e+DUJwEBVn/DQux42b2KQYNhWeaheK7nx5Ia6Y/w3Xpm/yqqYJh+KnZ+y8IgypjpscjL4qBkr944rw==",
       "license": "MIT",
       "dependencies": {
-        "@girs/cairo-1.0": "^1.0.0-4.0.0-beta.23",
-        "@girs/freetype2-2.0": "^2.0.0-4.0.0-beta.23",
-        "@girs/gdkpixbuf-2.0": "^2.0.0-4.0.0-beta.23",
-        "@girs/gio-2.0": "^2.84.0-4.0.0-beta.23",
-        "@girs/gjs": "^4.0.0-beta.23",
-        "@girs/glib-2.0": "^2.84.0-4.0.0-beta.23",
-        "@girs/gmodule-2.0": "^2.0.0-4.0.0-beta.23",
-        "@girs/gobject-2.0": "^2.84.0-4.0.0-beta.23",
-        "@girs/harfbuzz-0.0": "^9.0.0-4.0.0-beta.23",
-        "@girs/pango-1.0": "^1.56.4-4.0.0-beta.23",
-        "@girs/pangocairo-1.0": "^1.0.0-4.0.0-beta.23"
+        "@girs/cairo-1.0": "^4.1.0",
+        "@girs/freetype2-2.0": "^4.1.0",
+        "@girs/gdkpixbuf-2.0": "^4.1.0",
+        "@girs/gio-2.0": "^4.1.0",
+        "@girs/gjs": "^4.1.0",
+        "@girs/glib-2.0": "^4.1.0",
+        "@girs/gmodule-2.0": "^4.1.0",
+        "@girs/gobject-2.0": "^4.1.0",
+        "@girs/harfbuzz-0.0": "^4.1.0",
+        "@girs/pango-1.0": "^4.1.0",
+        "@girs/pangocairo-1.0": "^4.1.0"
       }
     },
     "node_modules/@girs/gdkpixbuf-2.0": {
-      "version": "2.0.0-4.0.0-beta.23",
-      "resolved": "https://registry.npmjs.org/@girs/gdkpixbuf-2.0/-/gdkpixbuf-2.0-2.0.0-4.0.0-beta.23.tgz",
-      "integrity": "sha512-Apku+aCEsosPXdEOnDtI3GPdX2Seo2rWUm10aY3ijGOnvafjmsJkHwWlThHzV850Ygi7dw3hBBys0z8hG6Cf1A==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@girs/gdkpixbuf-2.0/-/gdkpixbuf-2.0-4.1.0.tgz",
+      "integrity": "sha512-i89aPIgZPSD1/UNH5PlsT7660HtqfPu8eU5TeSedUV7H5kCWXRO11SqbRpGJoa3ScMu8UU0LOkgFB1f1x0QefA==",
       "license": "MIT",
       "dependencies": {
-        "@girs/gio-2.0": "^2.84.0-4.0.0-beta.23",
-        "@girs/gjs": "^4.0.0-beta.23",
-        "@girs/glib-2.0": "^2.84.0-4.0.0-beta.23",
-        "@girs/gmodule-2.0": "^2.0.0-4.0.0-beta.23",
-        "@girs/gobject-2.0": "^2.84.0-4.0.0-beta.23"
+        "@girs/gio-2.0": "^4.1.0",
+        "@girs/gjs": "^4.1.0",
+        "@girs/glib-2.0": "^4.1.0",
+        "@girs/gmodule-2.0": "^4.1.0",
+        "@girs/gobject-2.0": "^4.1.0"
       }
     },
     "node_modules/@girs/gdm-1.0": {
-      "version": "1.0.0-4.0.0-beta.23",
-      "resolved": "https://registry.npmjs.org/@girs/gdm-1.0/-/gdm-1.0-1.0.0-4.0.0-beta.23.tgz",
-      "integrity": "sha512-mKsmZTShn6xh0yzFcgzCddG3X2oXQi0nc5Q3AR3TPk+UURbREBdJwzeoIKI3Uqi03gwaRQVtFopHQ1B5IRSTAg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@girs/gdm-1.0/-/gdm-1.0-4.1.0.tgz",
+      "integrity": "sha512-JwIbQx1ABn0FSahUCXFyTrPkF7W38z6wyx2ydW+5ge5j2YKJTmadFd+/vK4BKyJgwkH9IjseLeWXzUrhQurBKQ==",
       "license": "MIT",
       "dependencies": {
-        "@girs/gio-2.0": "^2.84.0-4.0.0-beta.23",
-        "@girs/gjs": "^4.0.0-beta.23",
-        "@girs/glib-2.0": "^2.84.0-4.0.0-beta.23",
-        "@girs/gmodule-2.0": "^2.0.0-4.0.0-beta.23",
-        "@girs/gobject-2.0": "^2.84.0-4.0.0-beta.23"
+        "@girs/gio-2.0": "^4.1.0",
+        "@girs/gjs": "^4.1.0",
+        "@girs/glib-2.0": "^4.1.0",
+        "@girs/gmodule-2.0": "^4.1.0",
+        "@girs/gobject-2.0": "^4.1.0"
       }
     },
     "node_modules/@girs/gio-2.0": {
-      "version": "2.84.0-4.0.0-beta.23",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.84.0-4.0.0-beta.23.tgz",
-      "integrity": "sha512-FcGgYQ96KhdeFJvUYsIm0XmOYaYnTfpHKzPUOW4IcJm5q38RNDKgoijBMfedv3fMxnPDtpMb08ZFD6P1GjJY8A==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-4.1.0.tgz",
+      "integrity": "sha512-irRUpGEOHknlk4TNoOlAaBCg/jCGZKZv8Ulr23mmqf+MTI6ygDcbJY6bdHAf5dZfbgkOXjhXRl753j8F850W9Q==",
       "license": "MIT",
       "dependencies": {
-        "@girs/gjs": "^4.0.0-beta.23",
-        "@girs/glib-2.0": "^2.84.0-4.0.0-beta.23",
-        "@girs/gmodule-2.0": "^2.0.0-4.0.0-beta.23",
-        "@girs/gobject-2.0": "^2.84.0-4.0.0-beta.23"
+        "@girs/gjs": "^4.1.0",
+        "@girs/glib-2.0": "^4.1.0",
+        "@girs/gmodule-2.0": "^4.1.0",
+        "@girs/gobject-2.0": "^4.1.0"
+      }
+    },
+    "node_modules/@girs/giounix-2.0": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@girs/giounix-2.0/-/giounix-2.0-4.1.0.tgz",
+      "integrity": "sha512-e3JbHrw+MDbY4NzgMAIh7OUkA7bRfe8AuivklDPNF4b42q+ROyY2A1FZ+wYWGDYuRcjj8vokgDYIJ9hFy1wbAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@girs/gio-2.0": "^4.1.0",
+        "@girs/gjs": "^4.1.0",
+        "@girs/glib-2.0": "^4.1.0",
+        "@girs/gmodule-2.0": "^4.1.0",
+        "@girs/gobject-2.0": "^4.1.0"
       }
     },
     "node_modules/@girs/gjs": {
-      "version": "4.0.0-beta.23",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.0-beta.23.tgz",
-      "integrity": "sha512-Yz1s23WaGAsVHetWFReVxeYDJbVFtJ6KZ7u+qzWa/B3P2mB+5aXpGc7nV6Bx7GbRc48FuGgtbKxVo0rq26Ug/Q==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.1.0.tgz",
+      "integrity": "sha512-fF6beHhI/DW/4WF2JVDRVpjnWuae93euyr4NXOOTNXwaatDxbMB21jte+b0+Qc7eUEqjIUhV10Hq6ztl4hKWQg==",
       "license": "MIT",
       "dependencies": {
-        "@girs/cairo-1.0": "^1.0.0-4.0.0-beta.23",
-        "@girs/gio-2.0": "^2.84.0-4.0.0-beta.23",
-        "@girs/glib-2.0": "^2.84.0-4.0.0-beta.23",
-        "@girs/gobject-2.0": "^2.84.0-4.0.0-beta.23"
+        "@girs/cairo-1.0": "^4.1.0",
+        "@girs/gio-2.0": "^4.1.0",
+        "@girs/glib-2.0": "^4.1.0",
+        "@girs/gobject-2.0": "^4.1.0"
       }
     },
     "node_modules/@girs/gl-1.0": {
-      "version": "1.0.0-4.0.0-beta.23",
-      "resolved": "https://registry.npmjs.org/@girs/gl-1.0/-/gl-1.0-1.0.0-4.0.0-beta.23.tgz",
-      "integrity": "sha512-OaaqoeoZG2ovpf0SrDXDVNZOGk5Ay+tdw6M+sAsqjI+02epWgItWvdl3HfGd/82ENviIufw3s+vtWKodNUoWFw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@girs/gl-1.0/-/gl-1.0-4.1.0.tgz",
+      "integrity": "sha512-DO2ibBPLGJe9IRWjQQ1zR7bVjk6yBWsvnN1W1fCweNItavJ2+fwTkyo8uHUnYtn5X2FIlx+drkO8VggFnbwdVA==",
       "license": "MIT",
       "dependencies": {
-        "@girs/gjs": "^4.0.0-beta.23",
-        "@girs/gobject-2.0": "^2.84.0-4.0.0-beta.23"
+        "@girs/gjs": "^4.1.0",
+        "@girs/gobject-2.0": "^4.1.0"
       }
     },
     "node_modules/@girs/glib-2.0": {
-      "version": "2.84.0-4.0.0-beta.23",
-      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.84.0-4.0.0-beta.23.tgz",
-      "integrity": "sha512-epQae3f9rDeIrEgA9hOEiNAppJYQAfVRZ4Uh/0yO9NtAQR6PTfXUpjotw9ndjVxsHpEmRODoM2t/kytCYqKmVg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-4.1.0.tgz",
+      "integrity": "sha512-1OeIRobL8UEPP5HXD+lwEgM3643aof+mJ6GJD6TMtzuI9ZbuVyS9MJjQopHW+YrRSLAZwfSQXm2WipA3p3EZmg==",
       "license": "MIT",
       "dependencies": {
-        "@girs/gjs": "^4.0.0-beta.23",
-        "@girs/gobject-2.0": "^2.84.0-4.0.0-beta.23"
+        "@girs/gjs": "^4.1.0",
+        "@girs/gobject-2.0": "^4.1.0"
       }
     },
     "node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.0-beta.23",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.0-beta.23.tgz",
-      "integrity": "sha512-Dc+Pq1peNlwQ0o/WFsUzT1qt3oqgMLBhzjEfOTGAD0Jw1Ut3QCoBuryVFFNMIruOKnSSBoBnQO7Qelly5aSd2w==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-4.1.0.tgz",
+      "integrity": "sha512-yOFTdnvD61ohMDk12T2Rhcve6vP4/vZpwb/0iQYLu4ZOTD6cazMEdpM+ncZSj8beffbRqTfd7H81HNAriVVm5Q==",
       "license": "MIT",
       "dependencies": {
-        "@girs/gjs": "^4.0.0-beta.23",
-        "@girs/glib-2.0": "^2.84.0-4.0.0-beta.23",
-        "@girs/gobject-2.0": "^2.84.0-4.0.0-beta.23"
+        "@girs/gjs": "^4.1.0",
+        "@girs/glib-2.0": "^4.1.0",
+        "@girs/gobject-2.0": "^4.1.0"
       }
     },
     "node_modules/@girs/gnome-shell": {
-      "version": "48.0.2",
-      "resolved": "https://registry.npmjs.org/@girs/gnome-shell/-/gnome-shell-48.0.2.tgz",
-      "integrity": "sha512-hrlnTCc6y9O7GTn7M7YAufKdmIF8Et7ZFTRRUVXyv3hBHAor0bUFDrHdmVD+D7KdMHCJrtaLW6EtUCRQyovU2A==",
+      "version": "50.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gnome-shell/-/gnome-shell-50.0.4.tgz",
+      "integrity": "sha512-69phtdJHMPUBxVRDqfE4JWSZeauTIl0zFuILMIkJbqyHOb1U9sxN7yN59x+pJWGxVTktFz/Y9uXKjDzOcHlYFA==",
       "license": "MIT",
       "dependencies": {
-        "@girs/accountsservice-1.0": "1.0.0-4.0.0-beta.23",
-        "@girs/adw-1": "^1.8.0-4.0.0-beta.23",
-        "@girs/atk-1.0": "^2.56.0-4.0.0-beta.23",
-        "@girs/clutter-16": "^16.0.0-4.0.0-beta.23",
-        "@girs/cogl-2.0": "^2.0.0-4.0.0-beta.23",
-        "@girs/gcr-4": "^4.4.0-4.0.0-beta.23",
-        "@girs/gdm-1.0": "^1.0.0-4.0.0-beta.23",
-        "@girs/gio-2.0": "^2.84.0-4.0.0-beta.23",
-        "@girs/gjs": "^4.0.0-beta.23",
-        "@girs/glib-2.0": "^2.84.0-4.0.0-beta.23",
-        "@girs/gnomebg-4.0": "^4.0.0-4.0.0-beta.23",
-        "@girs/gnomebluetooth-3.0": "^3.0.0-4.0.0-beta.23",
-        "@girs/gnomedesktop-4.0": "^4.0.0-4.0.0-beta.23",
-        "@girs/gobject-2.0": "^2.84.0-4.0.0-beta.23",
-        "@girs/gtk-4.0": "^4.18.3-4.0.0-beta.23",
-        "@girs/gvc-1.0": "^1.0.0-4.0.0-beta.23",
-        "@girs/meta-16": "^16.0.0-4.0.0-beta.23",
-        "@girs/mtk-16": "^16.0.0-4.0.0-beta.23",
-        "@girs/polkit-1.0": "^1.0.0-4.0.0-beta.23",
-        "@girs/shell-16": "^16.0.0-4.0.0-beta.23",
-        "@girs/shew-0": "^0.0.0-4.0.0-beta.23",
-        "@girs/st-16": "^16.0.0-4.0.0-beta.23",
-        "@girs/upowerglib-1.0": "^0.99.1-4.0.0-beta.23"
+        "@girs/accountsservice-1.0": "^4.1.0",
+        "@girs/adw-1": "^4.1.0",
+        "@girs/atk-1.0": "^4.1.0",
+        "@girs/clutter-18": "^4.1.0",
+        "@girs/cogl-18": "^4.1.0",
+        "@girs/gcr-4": "^4.1.0",
+        "@girs/gdm-1.0": "^4.1.0",
+        "@girs/gio-2.0": "^4.1.0",
+        "@girs/giounix-2.0": "^4.1.0",
+        "@girs/gjs": "^4.1.0",
+        "@girs/glib-2.0": "^4.1.0",
+        "@girs/gnomebg-4.0": "^4.1.0",
+        "@girs/gnomebluetooth-3.0": "^4.1.0",
+        "@girs/gnomedesktop-4.0": "^4.1.0",
+        "@girs/gobject-2.0": "^4.1.0",
+        "@girs/gtk-4.0": "^4.1.0",
+        "@girs/gvc-1.0": "^4.1.0",
+        "@girs/meta-18": "^4.1.0",
+        "@girs/mtk-18": "^4.1.0",
+        "@girs/polkit-1.0": "^4.1.0",
+        "@girs/shell-18": "^4.1.0",
+        "@girs/shew-0": "^4.1.0",
+        "@girs/st-18": "^4.1.0",
+        "@girs/upowerglib-1.0": "^4.1.0"
       }
     },
     "node_modules/@girs/gnomebg-4.0": {
-      "version": "4.0.0-4.0.0-beta.23",
-      "resolved": "https://registry.npmjs.org/@girs/gnomebg-4.0/-/gnomebg-4.0-4.0.0-4.0.0-beta.23.tgz",
-      "integrity": "sha512-mXipjnVd+lUSMhUeugo49TXo32ihlKiN2ggpGDLIcD6ZfGe644DSgxoHFeYkn44HmNW39DvSqF9AcSvLP0cZJA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@girs/gnomebg-4.0/-/gnomebg-4.0-4.1.0.tgz",
+      "integrity": "sha512-9uha/ow4xAEqTiUkd0ew3vRlYTz3YHSG3HMQiGcVYdE/pWHFHjXQ5pToOIyQoDLL+HhoFy7XCUCCBxkgTuSk7w==",
       "license": "MIT",
       "dependencies": {
-        "@girs/cairo-1.0": "^1.0.0-4.0.0-beta.23",
-        "@girs/freetype2-2.0": "^2.0.0-4.0.0-beta.23",
-        "@girs/gdesktopenums-3.0": "^3.0.0-4.0.0-beta.23",
-        "@girs/gdk-4.0": "^4.0.0-4.0.0-beta.23",
-        "@girs/gdkpixbuf-2.0": "^2.0.0-4.0.0-beta.23",
-        "@girs/gio-2.0": "^2.84.0-4.0.0-beta.23",
-        "@girs/gjs": "^4.0.0-beta.23",
-        "@girs/glib-2.0": "^2.84.0-4.0.0-beta.23",
-        "@girs/gmodule-2.0": "^2.0.0-4.0.0-beta.23",
-        "@girs/gnomedesktop-4.0": "^4.0.0-4.0.0-beta.23",
-        "@girs/gobject-2.0": "^2.84.0-4.0.0-beta.23",
-        "@girs/harfbuzz-0.0": "^9.0.0-4.0.0-beta.23",
-        "@girs/pango-1.0": "^1.56.4-4.0.0-beta.23",
-        "@girs/pangocairo-1.0": "^1.0.0-4.0.0-beta.23"
+        "@girs/cairo-1.0": "^4.1.0",
+        "@girs/freetype2-2.0": "^4.1.0",
+        "@girs/gdesktopenums-3.0": "^4.1.0",
+        "@girs/gdk-4.0": "^4.1.0",
+        "@girs/gdkpixbuf-2.0": "^4.1.0",
+        "@girs/gio-2.0": "^4.1.0",
+        "@girs/gjs": "^4.1.0",
+        "@girs/glib-2.0": "^4.1.0",
+        "@girs/gmodule-2.0": "^4.1.0",
+        "@girs/gnomedesktop-4.0": "^4.1.0",
+        "@girs/gobject-2.0": "^4.1.0",
+        "@girs/harfbuzz-0.0": "^4.1.0",
+        "@girs/pango-1.0": "^4.1.0",
+        "@girs/pangocairo-1.0": "^4.1.0"
       }
     },
     "node_modules/@girs/gnomebluetooth-3.0": {
-      "version": "3.0.0-4.0.0-beta.23",
-      "resolved": "https://registry.npmjs.org/@girs/gnomebluetooth-3.0/-/gnomebluetooth-3.0-3.0.0-4.0.0-beta.23.tgz",
-      "integrity": "sha512-nLpLGgJwqaxtrie//bodjb9+CnELo6AqXM6QDi13C2pDlfMZGeCdLZj3kRvqqCLnPRJybIUVEjRLSEloZUHJnQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@girs/gnomebluetooth-3.0/-/gnomebluetooth-3.0-4.1.0.tgz",
+      "integrity": "sha512-V0Lo4JE0jotRbXZume/ZpoxUDyX8u1Iw8TD7i26iaMcsTQkNaEJdoNZfhL2WVW1rTU4pwkHD8IGJ2jZLTGInhA==",
       "license": "MIT",
       "dependencies": {
-        "@girs/gio-2.0": "^2.84.0-4.0.0-beta.23",
-        "@girs/gjs": "^4.0.0-beta.23",
-        "@girs/glib-2.0": "^2.84.0-4.0.0-beta.23",
-        "@girs/gmodule-2.0": "^2.0.0-4.0.0-beta.23",
-        "@girs/gobject-2.0": "^2.84.0-4.0.0-beta.23"
+        "@girs/gio-2.0": "^4.1.0",
+        "@girs/gjs": "^4.1.0",
+        "@girs/glib-2.0": "^4.1.0",
+        "@girs/gmodule-2.0": "^4.1.0",
+        "@girs/gobject-2.0": "^4.1.0"
       }
     },
     "node_modules/@girs/gnomedesktop-4.0": {
-      "version": "4.0.0-4.0.0-beta.23",
-      "resolved": "https://registry.npmjs.org/@girs/gnomedesktop-4.0/-/gnomedesktop-4.0-4.0.0-4.0.0-beta.23.tgz",
-      "integrity": "sha512-pkH6574kp371HH0F/M77lz7e8fK4hzpxaOz5w2cNoYdU3sMqUgET0nak0gxOsjuTBzd2gPZm3gQHhOz/J4AEtw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@girs/gnomedesktop-4.0/-/gnomedesktop-4.0-4.1.0.tgz",
+      "integrity": "sha512-Rh1kcycDgjI29sjuP+72SODLEqYKxVAZ+FV5DUBmDOVjfNLTlIPPM/1bsTvsqrZxpvZ3ISBPZlsMg7pxLrPWxw==",
       "license": "MIT",
       "dependencies": {
-        "@girs/gdesktopenums-3.0": "^3.0.0-4.0.0-beta.23",
-        "@girs/gdkpixbuf-2.0": "^2.0.0-4.0.0-beta.23",
-        "@girs/gio-2.0": "^2.84.0-4.0.0-beta.23",
-        "@girs/gjs": "^4.0.0-beta.23",
-        "@girs/glib-2.0": "^2.84.0-4.0.0-beta.23",
-        "@girs/gmodule-2.0": "^2.0.0-4.0.0-beta.23",
-        "@girs/gobject-2.0": "^2.84.0-4.0.0-beta.23"
+        "@girs/gdesktopenums-3.0": "^4.1.0",
+        "@girs/gdkpixbuf-2.0": "^4.1.0",
+        "@girs/gio-2.0": "^4.1.0",
+        "@girs/gjs": "^4.1.0",
+        "@girs/glib-2.0": "^4.1.0",
+        "@girs/gmodule-2.0": "^4.1.0",
+        "@girs/gobject-2.0": "^4.1.0"
       }
     },
     "node_modules/@girs/gobject-2.0": {
-      "version": "2.84.0-4.0.0-beta.23",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.84.0-4.0.0-beta.23.tgz",
-      "integrity": "sha512-GNWQDLo+Nmq2FQNPljKKh4Zplp8vZwwr0hj1sf4lbJ36zbVsovrhfNozqaph0XNjv8vtHeTcXUocGQprM9FHCg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-4.1.0.tgz",
+      "integrity": "sha512-5hPKlUOe8WdFQ6/uMS/0FEKC60ZNNJryIv9Qd4QB1jJkTHiah9TSQH4QVZNF14lQDxxYjAIgY8mcchGL2+bteA==",
       "license": "MIT",
       "dependencies": {
-        "@girs/gjs": "^4.0.0-beta.23",
-        "@girs/glib-2.0": "^2.84.0-4.0.0-beta.23"
+        "@girs/gjs": "^4.1.0",
+        "@girs/glib-2.0": "^4.1.0"
       }
     },
     "node_modules/@girs/graphene-1.0": {
-      "version": "1.0.0-4.0.0-beta.23",
-      "resolved": "https://registry.npmjs.org/@girs/graphene-1.0/-/graphene-1.0-1.0.0-4.0.0-beta.23.tgz",
-      "integrity": "sha512-C6HAR88uCAi6xCKip208tPdzYUBFICiCyBSBm+gVzniEfikNM4CVN7+tHHwp4Gd1FKixK5EMVDIYs5sCfToNWQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@girs/graphene-1.0/-/graphene-1.0-4.1.0.tgz",
+      "integrity": "sha512-fCwGsfj7wryyakZ9RzLT9+LS59nk9IDVd0OEsK15njhGqTEQ0/96MiFHvyVhCnjcU1ifgz/PdY5uGqKnLXth1g==",
       "license": "MIT",
       "dependencies": {
-        "@girs/gjs": "^4.0.0-beta.23",
-        "@girs/glib-2.0": "^2.84.0-4.0.0-beta.23",
-        "@girs/gobject-2.0": "^2.84.0-4.0.0-beta.23"
+        "@girs/gjs": "^4.1.0",
+        "@girs/glib-2.0": "^4.1.0",
+        "@girs/gobject-2.0": "^4.1.0"
       }
     },
     "node_modules/@girs/gsk-4.0": {
-      "version": "4.0.0-4.0.0-beta.23",
-      "resolved": "https://registry.npmjs.org/@girs/gsk-4.0/-/gsk-4.0-4.0.0-4.0.0-beta.23.tgz",
-      "integrity": "sha512-zLjklfxLjef6SV5VEQ2+52G/d+hQqmp6HbBu0/Jn5CLFFYe22LmDQWSEtGOn0NwKDL7XltXaxKoT/JBHEQsgcg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@girs/gsk-4.0/-/gsk-4.0-4.1.0.tgz",
+      "integrity": "sha512-wwgerEraNWX/sXiOnh3q2HrCC+kkdh2W8dXbP40eSEMmanIcXe7sC4nyDHSor1mp3y3XPvpS0BdiNfl4fxWx6A==",
       "license": "MIT",
       "dependencies": {
-        "@girs/cairo-1.0": "^1.0.0-4.0.0-beta.23",
-        "@girs/freetype2-2.0": "^2.0.0-4.0.0-beta.23",
-        "@girs/gdk-4.0": "^4.0.0-4.0.0-beta.23",
-        "@girs/gdkpixbuf-2.0": "^2.0.0-4.0.0-beta.23",
-        "@girs/gio-2.0": "^2.84.0-4.0.0-beta.23",
-        "@girs/gjs": "^4.0.0-beta.23",
-        "@girs/glib-2.0": "^2.84.0-4.0.0-beta.23",
-        "@girs/gmodule-2.0": "^2.0.0-4.0.0-beta.23",
-        "@girs/gobject-2.0": "^2.84.0-4.0.0-beta.23",
-        "@girs/graphene-1.0": "^1.0.0-4.0.0-beta.23",
-        "@girs/harfbuzz-0.0": "^9.0.0-4.0.0-beta.23",
-        "@girs/pango-1.0": "^1.56.4-4.0.0-beta.23",
-        "@girs/pangocairo-1.0": "^1.0.0-4.0.0-beta.23"
+        "@girs/cairo-1.0": "^4.1.0",
+        "@girs/freetype2-2.0": "^4.1.0",
+        "@girs/gdk-4.0": "^4.1.0",
+        "@girs/gdkpixbuf-2.0": "^4.1.0",
+        "@girs/gio-2.0": "^4.1.0",
+        "@girs/gjs": "^4.1.0",
+        "@girs/glib-2.0": "^4.1.0",
+        "@girs/gmodule-2.0": "^4.1.0",
+        "@girs/gobject-2.0": "^4.1.0",
+        "@girs/graphene-1.0": "^4.1.0",
+        "@girs/harfbuzz-0.0": "^4.1.0",
+        "@girs/pango-1.0": "^4.1.0",
+        "@girs/pangocairo-1.0": "^4.1.0"
       }
     },
     "node_modules/@girs/gtk-4.0": {
-      "version": "4.18.3-4.0.0-beta.23",
-      "resolved": "https://registry.npmjs.org/@girs/gtk-4.0/-/gtk-4.0-4.18.3-4.0.0-beta.23.tgz",
-      "integrity": "sha512-CsMPZLHQz+kWP81zR8AfPRpqUh9g1i5QNG08E9shj3Z9hvbR3goXmQXCSjgVxkcD40YsFn2tlc5FF/aztwY45Q==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@girs/gtk-4.0/-/gtk-4.0-4.1.0.tgz",
+      "integrity": "sha512-4stUvqZtBE3Fv6qhPF6yVVNhVgm9M5HD3WqTXEVxN3GmR8GtBTBSORHYPYSURQzfTASaHlctMmfg5II2A/KFVQ==",
       "license": "MIT",
       "dependencies": {
-        "@girs/cairo-1.0": "^1.0.0-4.0.0-beta.23",
-        "@girs/freetype2-2.0": "^2.0.0-4.0.0-beta.23",
-        "@girs/gdk-4.0": "^4.0.0-4.0.0-beta.23",
-        "@girs/gdkpixbuf-2.0": "^2.0.0-4.0.0-beta.23",
-        "@girs/gio-2.0": "^2.84.0-4.0.0-beta.23",
-        "@girs/gjs": "^4.0.0-beta.23",
-        "@girs/glib-2.0": "^2.84.0-4.0.0-beta.23",
-        "@girs/gmodule-2.0": "^2.0.0-4.0.0-beta.23",
-        "@girs/gobject-2.0": "^2.84.0-4.0.0-beta.23",
-        "@girs/graphene-1.0": "^1.0.0-4.0.0-beta.23",
-        "@girs/gsk-4.0": "^4.0.0-4.0.0-beta.23",
-        "@girs/harfbuzz-0.0": "^9.0.0-4.0.0-beta.23",
-        "@girs/pango-1.0": "^1.56.4-4.0.0-beta.23",
-        "@girs/pangocairo-1.0": "^1.0.0-4.0.0-beta.23"
+        "@girs/cairo-1.0": "^4.1.0",
+        "@girs/freetype2-2.0": "^4.1.0",
+        "@girs/gdk-4.0": "^4.1.0",
+        "@girs/gdkpixbuf-2.0": "^4.1.0",
+        "@girs/gio-2.0": "^4.1.0",
+        "@girs/gjs": "^4.1.0",
+        "@girs/glib-2.0": "^4.1.0",
+        "@girs/gmodule-2.0": "^4.1.0",
+        "@girs/gobject-2.0": "^4.1.0",
+        "@girs/graphene-1.0": "^4.1.0",
+        "@girs/gsk-4.0": "^4.1.0",
+        "@girs/harfbuzz-0.0": "^4.1.0",
+        "@girs/pango-1.0": "^4.1.0",
+        "@girs/pangocairo-1.0": "^4.1.0"
       }
     },
     "node_modules/@girs/gvc-1.0": {
-      "version": "1.0.0-4.0.0-beta.23",
-      "resolved": "https://registry.npmjs.org/@girs/gvc-1.0/-/gvc-1.0-1.0.0-4.0.0-beta.23.tgz",
-      "integrity": "sha512-Pzx/2KP0wBBMLmLcpwyVN6HE6SCPjlOqI2GCM81ztfb/EABAxAgq7liMua9RbIlo+eKj7e+GBb3rq8mEphgvcg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@girs/gvc-1.0/-/gvc-1.0-4.1.0.tgz",
+      "integrity": "sha512-L+y6qJUxw5IhrO45UipRrWoUInW1t0zhcHWfpw2ageZVTlEqaSsdk82dNPAElmNqRvcKUZUrgZLwJEWx+A2fUg==",
       "license": "MIT",
       "dependencies": {
-        "@girs/gio-2.0": "^2.84.0-4.0.0-beta.23",
-        "@girs/gjs": "^4.0.0-beta.23",
-        "@girs/glib-2.0": "^2.84.0-4.0.0-beta.23",
-        "@girs/gmodule-2.0": "^2.0.0-4.0.0-beta.23",
-        "@girs/gobject-2.0": "^2.84.0-4.0.0-beta.23"
+        "@girs/gio-2.0": "^4.1.0",
+        "@girs/gjs": "^4.1.0",
+        "@girs/glib-2.0": "^4.1.0",
+        "@girs/gmodule-2.0": "^4.1.0",
+        "@girs/gobject-2.0": "^4.1.0"
       }
     },
     "node_modules/@girs/harfbuzz-0.0": {
-      "version": "9.0.0-4.0.0-beta.23",
-      "resolved": "https://registry.npmjs.org/@girs/harfbuzz-0.0/-/harfbuzz-0.0-9.0.0-4.0.0-beta.23.tgz",
-      "integrity": "sha512-9uWYDEUhkyoClR4GHv69AMHRDtcNSwidtA8MG8c1rMDT5qWNWkwfQK5hwX8/oBCbL0LqJNeMfJByIQ3yLfgQGg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@girs/harfbuzz-0.0/-/harfbuzz-0.0-4.1.0.tgz",
+      "integrity": "sha512-370ny6RjcbGFRk6/50AFpCPteWgEN1y+2MyLXwSXGV0duJNlHBHOTtnuPTHkv+gGxp+s3/YTaQWa5UGzkVYN8g==",
       "license": "MIT",
       "dependencies": {
-        "@girs/freetype2-2.0": "^2.0.0-4.0.0-beta.23",
-        "@girs/gjs": "^4.0.0-beta.23",
-        "@girs/glib-2.0": "^2.84.0-4.0.0-beta.23",
-        "@girs/gobject-2.0": "^2.84.0-4.0.0-beta.23"
+        "@girs/freetype2-2.0": "^4.1.0",
+        "@girs/gjs": "^4.1.0",
+        "@girs/glib-2.0": "^4.1.0",
+        "@girs/gobject-2.0": "^4.1.0"
       }
     },
-    "node_modules/@girs/meta-16": {
-      "version": "16.0.0-4.0.0-beta.23",
-      "resolved": "https://registry.npmjs.org/@girs/meta-16/-/meta-16-16.0.0-4.0.0-beta.23.tgz",
-      "integrity": "sha512-qKto7mjzIS3D/uFRJxVWUFAV7VD0H2sbW3FDU9pvyVM++mtnrBnSi3SeTBJhIVFOhFCurcyn4SpqSoD7XkZ0uw==",
+    "node_modules/@girs/meta-18": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@girs/meta-18/-/meta-18-4.1.0.tgz",
+      "integrity": "sha512-KjEMVcOK6ny0nxxsdWI5RrxOSuhj7zh6mrH2EttaXbloqaLmbOCc2bhh61P7zjkhpanattuiEB8x+u3JQjj0tQ==",
       "license": "MIT",
       "dependencies": {
-        "@girs/atk-1.0": "^2.56.0-4.0.0-beta.23",
-        "@girs/cairo-1.0": "^1.0.0-4.0.0-beta.23",
-        "@girs/clutter-16": "^16.0.0-4.0.0-beta.23",
-        "@girs/cogl-16": "^16.0.0-4.0.0-beta.23",
-        "@girs/freetype2-2.0": "^2.0.0-4.0.0-beta.23",
-        "@girs/gdesktopenums-3.0": "^3.0.0-4.0.0-beta.23",
-        "@girs/gio-2.0": "^2.84.0-4.0.0-beta.23",
-        "@girs/gjs": "^4.0.0-beta.23",
-        "@girs/gl-1.0": "^1.0.0-4.0.0-beta.23",
-        "@girs/glib-2.0": "^2.84.0-4.0.0-beta.23",
-        "@girs/gmodule-2.0": "^2.0.0-4.0.0-beta.23",
-        "@girs/gobject-2.0": "^2.84.0-4.0.0-beta.23",
-        "@girs/graphene-1.0": "^1.0.0-4.0.0-beta.23",
-        "@girs/harfbuzz-0.0": "^9.0.0-4.0.0-beta.23",
-        "@girs/mtk-16": "^16.0.0-4.0.0-beta.23",
-        "@girs/pango-1.0": "^1.56.4-4.0.0-beta.23",
-        "@girs/xfixes-4.0": "^4.0.0-4.0.0-beta.23",
-        "@girs/xlib-2.0": "^2.0.0-4.0.0-beta.23"
+        "@girs/atk-1.0": "^4.1.0",
+        "@girs/cairo-1.0": "^4.1.0",
+        "@girs/clutter-18": "^4.1.0",
+        "@girs/cogl-18": "^4.1.0",
+        "@girs/freetype2-2.0": "^4.1.0",
+        "@girs/gdesktopenums-3.0": "^4.1.0",
+        "@girs/gio-2.0": "^4.1.0",
+        "@girs/gjs": "^4.1.0",
+        "@girs/gl-1.0": "^4.1.0",
+        "@girs/glib-2.0": "^4.1.0",
+        "@girs/gmodule-2.0": "^4.1.0",
+        "@girs/gobject-2.0": "^4.1.0",
+        "@girs/graphene-1.0": "^4.1.0",
+        "@girs/harfbuzz-0.0": "^4.1.0",
+        "@girs/mtk-18": "^4.1.0",
+        "@girs/pango-1.0": "^4.1.0",
+        "@girs/xfixes-4.0": "^4.1.0",
+        "@girs/xlib-2.0": "^4.1.0"
       }
     },
-    "node_modules/@girs/mtk-16": {
-      "version": "16.0.0-4.0.0-beta.23",
-      "resolved": "https://registry.npmjs.org/@girs/mtk-16/-/mtk-16-16.0.0-4.0.0-beta.23.tgz",
-      "integrity": "sha512-nLiqoarVgY4nPl6aBsuxzRdiRMGwyXmzlbLSTtCPUsK73QeKWfsdNtU4xDeC3WkBNtYM8mnosF/sqBodbR+lrg==",
+    "node_modules/@girs/mtk-18": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@girs/mtk-18/-/mtk-18-4.1.0.tgz",
+      "integrity": "sha512-6Jc6i+g/CRbjskXUw8pwLxfLb4/YVsXrWZy6W4QWgbZzJAxIEZqCBCEhMKSJEcpuyfY382wOpEAGAZCYgHGxrw==",
       "license": "MIT",
       "dependencies": {
-        "@girs/gjs": "^4.0.0-beta.23",
-        "@girs/glib-2.0": "^2.84.0-4.0.0-beta.23",
-        "@girs/gobject-2.0": "^2.84.0-4.0.0-beta.23",
-        "@girs/graphene-1.0": "^1.0.0-4.0.0-beta.23"
+        "@girs/gjs": "^4.1.0",
+        "@girs/glib-2.0": "^4.1.0",
+        "@girs/gobject-2.0": "^4.1.0",
+        "@girs/graphene-1.0": "^4.1.0"
       }
     },
     "node_modules/@girs/nm-1.0": {
-      "version": "1.49.4-4.0.0-beta.23",
-      "resolved": "https://registry.npmjs.org/@girs/nm-1.0/-/nm-1.0-1.49.4-4.0.0-beta.23.tgz",
-      "integrity": "sha512-N0TCk6b0KDH4p/h91+aiusSHdJ4986vjkc5NFKEPS+QHBUyqHU4nf/+RAU1bfII/KU2rQejJfx/yDRGc6PwyIw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@girs/nm-1.0/-/nm-1.0-4.1.0.tgz",
+      "integrity": "sha512-ggBoqJ1bBeqWUMkoZTMGgTVVB5FWZk3Wm+bVUzMvrcOEhriS4XiToxvtOZ4SyObvNMaUvYku/pIAADxpVTWacg==",
       "license": "MIT",
       "dependencies": {
-        "@girs/gio-2.0": "^2.84.0-4.0.0-beta.23",
-        "@girs/gjs": "^4.0.0-beta.23",
-        "@girs/glib-2.0": "^2.84.0-4.0.0-beta.23",
-        "@girs/gmodule-2.0": "^2.0.0-4.0.0-beta.23",
-        "@girs/gobject-2.0": "^2.84.0-4.0.0-beta.23"
+        "@girs/gio-2.0": "^4.1.0",
+        "@girs/gjs": "^4.1.0",
+        "@girs/glib-2.0": "^4.1.0",
+        "@girs/gmodule-2.0": "^4.1.0",
+        "@girs/gobject-2.0": "^4.1.0"
       }
     },
     "node_modules/@girs/pango-1.0": {
-      "version": "1.56.4-4.0.0-beta.23",
-      "resolved": "https://registry.npmjs.org/@girs/pango-1.0/-/pango-1.0-1.56.4-4.0.0-beta.23.tgz",
-      "integrity": "sha512-gezMBRQerPUt7xLGzx34W0UFK+AVf2S7GPKm1LK8dGGq4qnjkkEdf1w2wcN/iV3lLCxz1+4U0MmBArrqcSe2hQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@girs/pango-1.0/-/pango-1.0-4.1.0.tgz",
+      "integrity": "sha512-hHDkTA1fyEDsfn4z2q8xDszXS3PgAqcKEjpFL4Xy0w70+JGW+704uxdi5qLRsi/wfjo6bc5K1v2pNsg3yYLiCg==",
       "license": "MIT",
       "dependencies": {
-        "@girs/cairo-1.0": "^1.0.0-4.0.0-beta.23",
-        "@girs/freetype2-2.0": "^2.0.0-4.0.0-beta.23",
-        "@girs/gio-2.0": "^2.84.0-4.0.0-beta.23",
-        "@girs/gjs": "^4.0.0-beta.23",
-        "@girs/glib-2.0": "^2.84.0-4.0.0-beta.23",
-        "@girs/gmodule-2.0": "^2.0.0-4.0.0-beta.23",
-        "@girs/gobject-2.0": "^2.84.0-4.0.0-beta.23",
-        "@girs/harfbuzz-0.0": "^9.0.0-4.0.0-beta.23"
+        "@girs/cairo-1.0": "^4.1.0",
+        "@girs/freetype2-2.0": "^4.1.0",
+        "@girs/gio-2.0": "^4.1.0",
+        "@girs/gjs": "^4.1.0",
+        "@girs/glib-2.0": "^4.1.0",
+        "@girs/gmodule-2.0": "^4.1.0",
+        "@girs/gobject-2.0": "^4.1.0",
+        "@girs/harfbuzz-0.0": "^4.1.0"
       }
     },
     "node_modules/@girs/pangocairo-1.0": {
-      "version": "1.0.0-4.0.0-beta.23",
-      "resolved": "https://registry.npmjs.org/@girs/pangocairo-1.0/-/pangocairo-1.0-1.0.0-4.0.0-beta.23.tgz",
-      "integrity": "sha512-8omT0HAxzj+IDLIYLv08GjXc43yRs5QXxttEtV+/0aDWX0XOyaenuWg9cNS8lwBKPIa5tW9lcdLCudyBJ2xcqA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@girs/pangocairo-1.0/-/pangocairo-1.0-4.1.0.tgz",
+      "integrity": "sha512-F1C18l6cQN8xCz4M+1zarllpMRkpPjlZcYiWVA9lTPDZnyfr47JAZGTBQUo/iayKfABMO1BHxeBJqOP2e87S3g==",
       "license": "MIT",
       "dependencies": {
-        "@girs/cairo-1.0": "^1.0.0-4.0.0-beta.23",
-        "@girs/freetype2-2.0": "^2.0.0-4.0.0-beta.23",
-        "@girs/gio-2.0": "^2.84.0-4.0.0-beta.23",
-        "@girs/gjs": "^4.0.0-beta.23",
-        "@girs/glib-2.0": "^2.84.0-4.0.0-beta.23",
-        "@girs/gmodule-2.0": "^2.0.0-4.0.0-beta.23",
-        "@girs/gobject-2.0": "^2.84.0-4.0.0-beta.23",
-        "@girs/harfbuzz-0.0": "^9.0.0-4.0.0-beta.23",
-        "@girs/pango-1.0": "^1.56.4-4.0.0-beta.23"
+        "@girs/cairo-1.0": "^4.1.0",
+        "@girs/freetype2-2.0": "^4.1.0",
+        "@girs/gio-2.0": "^4.1.0",
+        "@girs/gjs": "^4.1.0",
+        "@girs/glib-2.0": "^4.1.0",
+        "@girs/gmodule-2.0": "^4.1.0",
+        "@girs/gobject-2.0": "^4.1.0",
+        "@girs/harfbuzz-0.0": "^4.1.0",
+        "@girs/pango-1.0": "^4.1.0"
       }
     },
     "node_modules/@girs/polkit-1.0": {
-      "version": "1.0.0-4.0.0-beta.23",
-      "resolved": "https://registry.npmjs.org/@girs/polkit-1.0/-/polkit-1.0-1.0.0-4.0.0-beta.23.tgz",
-      "integrity": "sha512-jayhgMeindShO2SMbEZduYcFrU5GaHjgJWK7zGdkg3QDSKhy1pZJwxmDJcq/yvNtMmcGsws7aTrLcnAYrhjg0w==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@girs/polkit-1.0/-/polkit-1.0-4.1.0.tgz",
+      "integrity": "sha512-lYyv3udRMc9umEBDCB9YlbVKdaIn/CGxGe7EOxI7HzX0/aMbWMHI6XfhDHYwyrcmnIDD0BviVZxPOaYDXTTimA==",
       "license": "MIT",
       "dependencies": {
-        "@girs/gio-2.0": "^2.84.0-4.0.0-beta.23",
-        "@girs/gjs": "^4.0.0-beta.23",
-        "@girs/glib-2.0": "^2.84.0-4.0.0-beta.23",
-        "@girs/gmodule-2.0": "^2.0.0-4.0.0-beta.23",
-        "@girs/gobject-2.0": "^2.84.0-4.0.0-beta.23"
+        "@girs/gio-2.0": "^4.1.0",
+        "@girs/gjs": "^4.1.0",
+        "@girs/glib-2.0": "^4.1.0",
+        "@girs/gmodule-2.0": "^4.1.0",
+        "@girs/gobject-2.0": "^4.1.0"
       }
     },
     "node_modules/@girs/polkitagent-1.0": {
-      "version": "1.0.0-4.0.0-beta.23",
-      "resolved": "https://registry.npmjs.org/@girs/polkitagent-1.0/-/polkitagent-1.0-1.0.0-4.0.0-beta.23.tgz",
-      "integrity": "sha512-LAwHOtoaWJ1SuAKBKXeTa2pgHZGUyN6X9qujHpnzVDpli1gawlY7irb7fk/sCkc/Nxt4IgN2YfCE+BENi3726Q==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@girs/polkitagent-1.0/-/polkitagent-1.0-4.1.0.tgz",
+      "integrity": "sha512-RYY7dceP+HQkOAaCM3uucmLsnnp4lNRxVH4PTxQE/yDt46mG2YjWE+pb7ksoZph4LWcMgaOhUKpLEJdNtULLRQ==",
       "license": "MIT",
       "dependencies": {
-        "@girs/gio-2.0": "^2.84.0-4.0.0-beta.23",
-        "@girs/gjs": "^4.0.0-beta.23",
-        "@girs/glib-2.0": "^2.84.0-4.0.0-beta.23",
-        "@girs/gmodule-2.0": "^2.0.0-4.0.0-beta.23",
-        "@girs/gobject-2.0": "^2.84.0-4.0.0-beta.23",
-        "@girs/polkit-1.0": "^1.0.0-4.0.0-beta.23"
+        "@girs/gio-2.0": "^4.1.0",
+        "@girs/gjs": "^4.1.0",
+        "@girs/glib-2.0": "^4.1.0",
+        "@girs/gmodule-2.0": "^4.1.0",
+        "@girs/gobject-2.0": "^4.1.0",
+        "@girs/polkit-1.0": "^4.1.0"
       }
     },
-    "node_modules/@girs/shell-16": {
-      "version": "16.0.0-4.0.0-beta.23",
-      "resolved": "https://registry.npmjs.org/@girs/shell-16/-/shell-16-16.0.0-4.0.0-beta.23.tgz",
-      "integrity": "sha512-Gynf4hxPnbuzW6FkmMIay1ky//tmAIWaOvXgV1So+i2BlyglJXCo2WYSCxjEtp0+JrNvSWBnKf7Hnh9S++30dQ==",
+    "node_modules/@girs/shell-18": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@girs/shell-18/-/shell-18-4.1.0.tgz",
+      "integrity": "sha512-AGFHEDHTeYryprLkhYZdQTQVrbIgpA0qJTvXDnN+aeIL5wE34OBI9/GjxnQM34i6r/3t1uiDkgYeElOQ54vH1A==",
       "license": "MIT",
       "dependencies": {
-        "@girs/atk-1.0": "^2.56.0-4.0.0-beta.23",
-        "@girs/cairo-1.0": "^1.0.0-4.0.0-beta.23",
-        "@girs/clutter-16": "^16.0.0-4.0.0-beta.23",
-        "@girs/cogl-16": "^16.0.0-4.0.0-beta.23",
-        "@girs/freetype2-2.0": "^2.0.0-4.0.0-beta.23",
-        "@girs/gck-2": "^4.4.0-4.0.0-beta.23",
-        "@girs/gcr-4": "^4.4.0-4.0.0-beta.23",
-        "@girs/gdesktopenums-3.0": "^3.0.0-4.0.0-beta.23",
-        "@girs/gdkpixbuf-2.0": "^2.0.0-4.0.0-beta.23",
-        "@girs/gio-2.0": "^2.84.0-4.0.0-beta.23",
-        "@girs/gjs": "^4.0.0-beta.23",
-        "@girs/gl-1.0": "^1.0.0-4.0.0-beta.23",
-        "@girs/glib-2.0": "^2.84.0-4.0.0-beta.23",
-        "@girs/gmodule-2.0": "^2.0.0-4.0.0-beta.23",
-        "@girs/gobject-2.0": "^2.84.0-4.0.0-beta.23",
-        "@girs/graphene-1.0": "^1.0.0-4.0.0-beta.23",
-        "@girs/gvc-1.0": "^1.0.0-4.0.0-beta.23",
-        "@girs/harfbuzz-0.0": "^9.0.0-4.0.0-beta.23",
-        "@girs/meta-16": "^16.0.0-4.0.0-beta.23",
-        "@girs/mtk-16": "^16.0.0-4.0.0-beta.23",
-        "@girs/nm-1.0": "^1.49.4-4.0.0-beta.23",
-        "@girs/pango-1.0": "^1.56.4-4.0.0-beta.23",
-        "@girs/polkit-1.0": "^1.0.0-4.0.0-beta.23",
-        "@girs/polkitagent-1.0": "^1.0.0-4.0.0-beta.23",
-        "@girs/st-16": "^16.0.0-4.0.0-beta.23",
-        "@girs/xfixes-4.0": "^4.0.0-4.0.0-beta.23",
-        "@girs/xlib-2.0": "^2.0.0-4.0.0-beta.23"
+        "@girs/atk-1.0": "^4.1.0",
+        "@girs/cairo-1.0": "^4.1.0",
+        "@girs/clutter-18": "^4.1.0",
+        "@girs/cogl-18": "^4.1.0",
+        "@girs/freetype2-2.0": "^4.1.0",
+        "@girs/gck-2": "^4.1.0",
+        "@girs/gcr-4": "^4.1.0",
+        "@girs/gdesktopenums-3.0": "^4.1.0",
+        "@girs/gdkpixbuf-2.0": "^4.1.0",
+        "@girs/gio-2.0": "^4.1.0",
+        "@girs/giounix-2.0": "^4.1.0",
+        "@girs/gjs": "^4.1.0",
+        "@girs/gl-1.0": "^4.1.0",
+        "@girs/glib-2.0": "^4.1.0",
+        "@girs/gmodule-2.0": "^4.1.0",
+        "@girs/gobject-2.0": "^4.1.0",
+        "@girs/graphene-1.0": "^4.1.0",
+        "@girs/gvc-1.0": "^4.1.0",
+        "@girs/harfbuzz-0.0": "^4.1.0",
+        "@girs/meta-18": "^4.1.0",
+        "@girs/mtk-18": "^4.1.0",
+        "@girs/nm-1.0": "^4.1.0",
+        "@girs/pango-1.0": "^4.1.0",
+        "@girs/polkit-1.0": "^4.1.0",
+        "@girs/polkitagent-1.0": "^4.1.0",
+        "@girs/st-18": "^4.1.0",
+        "@girs/xfixes-4.0": "^4.1.0",
+        "@girs/xlib-2.0": "^4.1.0"
       }
     },
     "node_modules/@girs/shew-0": {
-      "version": "0.0.0-4.0.0-beta.23",
-      "resolved": "https://registry.npmjs.org/@girs/shew-0/-/shew-0-0.0.0-4.0.0-beta.23.tgz",
-      "integrity": "sha512-voxcO7uev7ZnrPfGoz9y0HV3fToXe5Q/Dzn1uKDVmebFKlcl8Oznr/zbPEuym+K7lKc4LVMos+f7HelxVfD27w==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@girs/shew-0/-/shew-0-4.1.0.tgz",
+      "integrity": "sha512-ErZ+tzi9SQBHIqOD+Arprk7iFw8cweQmp2aXQe4yol2i6cj8VbSow2OinjgBBJzoHGyPCKCuIQLzjDEzTWKIig==",
       "license": "MIT",
       "dependencies": {
-        "@girs/cairo-1.0": "^1.0.0-4.0.0-beta.23",
-        "@girs/freetype2-2.0": "^2.0.0-4.0.0-beta.23",
-        "@girs/gdk-4.0": "^4.0.0-4.0.0-beta.23",
-        "@girs/gdkpixbuf-2.0": "^2.0.0-4.0.0-beta.23",
-        "@girs/gio-2.0": "^2.84.0-4.0.0-beta.23",
-        "@girs/gjs": "^4.0.0-beta.23",
-        "@girs/glib-2.0": "^2.84.0-4.0.0-beta.23",
-        "@girs/gmodule-2.0": "^2.0.0-4.0.0-beta.23",
-        "@girs/gobject-2.0": "^2.84.0-4.0.0-beta.23",
-        "@girs/graphene-1.0": "^1.0.0-4.0.0-beta.23",
-        "@girs/gsk-4.0": "^4.0.0-4.0.0-beta.23",
-        "@girs/gtk-4.0": "^4.18.3-4.0.0-beta.23",
-        "@girs/harfbuzz-0.0": "^9.0.0-4.0.0-beta.23",
-        "@girs/pango-1.0": "^1.56.4-4.0.0-beta.23",
-        "@girs/pangocairo-1.0": "^1.0.0-4.0.0-beta.23"
+        "@girs/cairo-1.0": "^4.1.0",
+        "@girs/freetype2-2.0": "^4.1.0",
+        "@girs/gdk-4.0": "^4.1.0",
+        "@girs/gdkpixbuf-2.0": "^4.1.0",
+        "@girs/gio-2.0": "^4.1.0",
+        "@girs/gjs": "^4.1.0",
+        "@girs/glib-2.0": "^4.1.0",
+        "@girs/gmodule-2.0": "^4.1.0",
+        "@girs/gobject-2.0": "^4.1.0",
+        "@girs/graphene-1.0": "^4.1.0",
+        "@girs/gsk-4.0": "^4.1.0",
+        "@girs/gtk-4.0": "^4.1.0",
+        "@girs/harfbuzz-0.0": "^4.1.0",
+        "@girs/pango-1.0": "^4.1.0",
+        "@girs/pangocairo-1.0": "^4.1.0"
       }
     },
-    "node_modules/@girs/st-16": {
-      "version": "16.0.0-4.0.0-beta.23",
-      "resolved": "https://registry.npmjs.org/@girs/st-16/-/st-16-16.0.0-4.0.0-beta.23.tgz",
-      "integrity": "sha512-eVaxgQZzwTyhKSv5OD9phI2c8SzKVnMA6b2SahJ4V/PR6pC65JsGZFmJE6WdtU23XKdFEoMnG/CKegKKyaw0eg==",
+    "node_modules/@girs/st-18": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@girs/st-18/-/st-18-4.1.0.tgz",
+      "integrity": "sha512-Ki/B94KToCbl19nU3q1RaPcwU2X3jswBXZhSRFA+8envBdFRWvXaIxEyB9rL9dK5TlO17/MygdCc3cdBmmc4jA==",
       "license": "MIT",
       "dependencies": {
-        "@girs/atk-1.0": "^2.56.0-4.0.0-beta.23",
-        "@girs/cairo-1.0": "^1.0.0-4.0.0-beta.23",
-        "@girs/clutter-16": "^16.0.0-4.0.0-beta.23",
-        "@girs/cogl-16": "^16.0.0-4.0.0-beta.23",
-        "@girs/freetype2-2.0": "^2.0.0-4.0.0-beta.23",
-        "@girs/gdesktopenums-3.0": "^3.0.0-4.0.0-beta.23",
-        "@girs/gdkpixbuf-2.0": "^2.0.0-4.0.0-beta.23",
-        "@girs/gio-2.0": "^2.84.0-4.0.0-beta.23",
-        "@girs/gjs": "^4.0.0-beta.23",
-        "@girs/gl-1.0": "^1.0.0-4.0.0-beta.23",
-        "@girs/glib-2.0": "^2.84.0-4.0.0-beta.23",
-        "@girs/gmodule-2.0": "^2.0.0-4.0.0-beta.23",
-        "@girs/gobject-2.0": "^2.84.0-4.0.0-beta.23",
-        "@girs/graphene-1.0": "^1.0.0-4.0.0-beta.23",
-        "@girs/harfbuzz-0.0": "^9.0.0-4.0.0-beta.23",
-        "@girs/meta-16": "^16.0.0-4.0.0-beta.23",
-        "@girs/mtk-16": "^16.0.0-4.0.0-beta.23",
-        "@girs/pango-1.0": "^1.56.4-4.0.0-beta.23",
-        "@girs/xfixes-4.0": "^4.0.0-4.0.0-beta.23",
-        "@girs/xlib-2.0": "^2.0.0-4.0.0-beta.23"
+        "@girs/atk-1.0": "^4.1.0",
+        "@girs/cairo-1.0": "^4.1.0",
+        "@girs/clutter-18": "^4.1.0",
+        "@girs/cogl-18": "^4.1.0",
+        "@girs/freetype2-2.0": "^4.1.0",
+        "@girs/gdesktopenums-3.0": "^4.1.0",
+        "@girs/gdkpixbuf-2.0": "^4.1.0",
+        "@girs/gio-2.0": "^4.1.0",
+        "@girs/gjs": "^4.1.0",
+        "@girs/gl-1.0": "^4.1.0",
+        "@girs/glib-2.0": "^4.1.0",
+        "@girs/gmodule-2.0": "^4.1.0",
+        "@girs/gobject-2.0": "^4.1.0",
+        "@girs/graphene-1.0": "^4.1.0",
+        "@girs/harfbuzz-0.0": "^4.1.0",
+        "@girs/meta-18": "^4.1.0",
+        "@girs/mtk-18": "^4.1.0",
+        "@girs/pango-1.0": "^4.1.0",
+        "@girs/xfixes-4.0": "^4.1.0",
+        "@girs/xlib-2.0": "^4.1.0"
       }
     },
     "node_modules/@girs/upowerglib-1.0": {
-      "version": "0.99.1-4.0.0-beta.23",
-      "resolved": "https://registry.npmjs.org/@girs/upowerglib-1.0/-/upowerglib-1.0-0.99.1-4.0.0-beta.23.tgz",
-      "integrity": "sha512-GpWzIVdXSK2dhk1I7utZIzao7NLSIP4iZ/EOXUUV7HSaDeNW/1orR5jUZMJOQhfH8w0JiFsfaoZTm/7TTZlUPg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@girs/upowerglib-1.0/-/upowerglib-1.0-4.1.0.tgz",
+      "integrity": "sha512-GLLY6HiRPD0LainaJc442l3Vf/vSu2cii5IYK36BvGjOSx712cp5d4/Xb80a/TA9/Jrbqr3tO8j8rzNjGRrmAw==",
       "license": "MIT",
       "dependencies": {
-        "@girs/gio-2.0": "^2.84.0-4.0.0-beta.23",
-        "@girs/gjs": "^4.0.0-beta.23",
-        "@girs/glib-2.0": "^2.84.0-4.0.0-beta.23",
-        "@girs/gmodule-2.0": "^2.0.0-4.0.0-beta.23",
-        "@girs/gobject-2.0": "^2.84.0-4.0.0-beta.23"
+        "@girs/gio-2.0": "^4.1.0",
+        "@girs/gjs": "^4.1.0",
+        "@girs/glib-2.0": "^4.1.0",
+        "@girs/gmodule-2.0": "^4.1.0",
+        "@girs/gobject-2.0": "^4.1.0"
       }
     },
     "node_modules/@girs/xfixes-4.0": {
-      "version": "4.0.0-4.0.0-beta.23",
-      "resolved": "https://registry.npmjs.org/@girs/xfixes-4.0/-/xfixes-4.0-4.0.0-4.0.0-beta.23.tgz",
-      "integrity": "sha512-66pjrl+5kXurr1NRBE6rFBixQp3F15HvYrWkzXzrTJABTt3H1it82jsJkprA1h3Z7Z8ucxx/u3fEWMJGY5xUjQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@girs/xfixes-4.0/-/xfixes-4.0-4.1.0.tgz",
+      "integrity": "sha512-WiS3TneSclpsUHcgXsU5Gj3LOcxiYeT8h2FM4PbOVarOGfMMNTdxDWp3kJdRuuUboKaepLCGSZY3MN53YtT6jA==",
       "license": "MIT",
       "dependencies": {
-        "@girs/gjs": "^4.0.0-beta.23",
-        "@girs/gobject-2.0": "^2.84.0-4.0.0-beta.23"
+        "@girs/gjs": "^4.1.0",
+        "@girs/gobject-2.0": "^4.1.0"
       }
     },
     "node_modules/@girs/xlib-2.0": {
-      "version": "2.0.0-4.0.0-beta.23",
-      "resolved": "https://registry.npmjs.org/@girs/xlib-2.0/-/xlib-2.0-2.0.0-4.0.0-beta.23.tgz",
-      "integrity": "sha512-FETH5hCvxs45ZonJ948nosy0tXAIZPTyrtF0r6TwVvjMHSHuINXsU4ylxM7Uc0xeuFh5KL+3ShAPXzwi9FynVg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@girs/xlib-2.0/-/xlib-2.0-4.1.0.tgz",
+      "integrity": "sha512-dLV0ObD16/+909MXi41ccYZqeh5G8uvi4uSzaX4H++kgOOA0D81PBacPjxLEEGizbLw/rzf46elwy6OHyjc/8Q==",
       "license": "MIT",
       "dependencies": {
-        "@girs/gjs": "^4.0.0-beta.23",
-        "@girs/gobject-2.0": "^2.84.0-4.0.0-beta.23"
+        "@girs/gjs": "^4.1.0",
+        "@girs/gobject-2.0": "^4.1.0"
       }
     },
     "node_modules/@humanfs/core": {
@@ -885,10 +861,30 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@sindresorhus/base62": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/base62/-/base62-1.0.0.tgz",
+      "integrity": "sha512-TeheYy0ILzBEI/CO55CP6zJCSdSWeRtGnHy8U8dWSUH4I68iqTsy7HkMktR4xakThc9jotkPQUXT4ITdbV7cHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@types/esrecurse": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
-      "integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
     },
@@ -899,10 +895,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.65.0.tgz",
+      "integrity": "sha512-JSSwWNy+H0E/01jJEM+hrX6N0OFDzFzeIhHFSAS01tlVaevpG8cFyYRPhS5yjGOvBUx3sqQHVMjCL1CAZZMxBg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
     "node_modules/acorn": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -923,9 +933,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -939,22 +949,6 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
     "node_modules/are-docs-informative": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/are-docs-informative/-/are-docs-informative-0.0.2.tgz",
@@ -965,94 +959,38 @@
         "node": ">=14"
       }
     },
-    "node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
-      "license": "Python-2.0"
-    },
     "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/callsites": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
+        "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
+        "node": "18 || 20 || >=22"
       }
-    },
-    "node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/comment-parser": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.1.tgz",
-      "integrity": "sha512-buhp5kePrmda3vhc5B9t7pUQXAb2Tnd0qgpkIhPhkHXxJpiPJ11H0ZEU0oBpJ2QztSbzG/ZxMj/CHsYJqRHmyg==",
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.7.tgz",
+      "integrity": "sha512-0h+uSNtQGW3D98eQt3jJ8L06Fves8hncB4V/PKdw/Qb8Hnk19VaKuTr55UNRYiSoVa7WwrFls+rh3ux9agmkeQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 12.0.0"
       }
-    },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -1070,9 +1008,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1108,33 +1046,33 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.39.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.1.tgz",
-      "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.7.0.tgz",
+      "integrity": "sha512-GVTD7s1vdIl6UYvAfriOPeY1Df8LIZjfofLvHwde+erDHGGuHyuM6xoxRxmHiebhYuD2p1vN4wWh0XzPARSGDQ==",
       "dev": true,
       "license": "MIT",
+      "workspaces": [
+        "packages/*"
+      ],
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
-        "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.21.1",
-        "@eslint/config-helpers": "^0.4.2",
-        "@eslint/core": "^0.17.0",
-        "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.39.1",
-        "@eslint/plugin-kit": "^0.4.1",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@eslint/config-array": "^0.23.5",
+        "@eslint/config-helpers": "^0.6.0",
+        "@eslint/core": "^1.2.1",
+        "@eslint/plugin-kit": "^0.7.2",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
         "@types/estree": "^1.0.6",
-        "ajv": "^6.12.4",
-        "chalk": "^4.0.0",
+        "ajv": "^6.14.0",
         "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^8.4.0",
-        "eslint-visitor-keys": "^4.2.1",
-        "espree": "^10.4.0",
-        "esquery": "^1.5.0",
+        "eslint-scope": "^9.1.2",
+        "eslint-visitor-keys": "^5.0.1",
+        "espree": "^11.2.0",
+        "esquery": "^1.7.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^8.0.0",
@@ -1144,8 +1082,7 @@
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
-        "lodash.merge": "^4.6.2",
-        "minimatch": "^3.1.2",
+        "minimatch": "^10.2.4",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3"
       },
@@ -1153,7 +1090,7 @@
         "eslint": "bin/eslint.js"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://eslint.org/donate"
@@ -1168,42 +1105,48 @@
       }
     },
     "node_modules/eslint-plugin-jsdoc": {
-      "version": "50.6.11",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-50.6.11.tgz",
-      "integrity": "sha512-k4+MnBCGR8cuIB5MZ++FGd4gbXxjob2rX1Nq0q3nWFF4xSGZENTgTLZSjb+u9B8SAnP6lpGV2FJrBjllV3pVSg==",
+      "version": "63.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-63.2.0.tgz",
+      "integrity": "sha512-tccz9igEV5mTKVAwo/KwXqKP7ENqa3a+LpRFuEPAP3k/+SXG4T0sOvA+c2wwTD/TLNrH9MCW4LIu4xEExkJdzg==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@es-joy/jsdoccomment": "~0.49.0",
+        "@es-joy/jsdoccomment": "~0.88.0",
+        "@es-joy/resolve.exports": "1.2.0",
         "are-docs-informative": "^0.0.2",
-        "comment-parser": "1.4.1",
-        "debug": "^4.3.6",
+        "comment-parser": "1.4.7",
+        "debug": "^4.4.3",
         "escape-string-regexp": "^4.0.0",
-        "espree": "^10.1.0",
-        "esquery": "^1.6.0",
+        "espree": "^11.2.0",
+        "esquery": "^1.7.0",
+        "html-entities": "^2.6.0",
+        "object-deep-merge": "^2.0.1",
         "parse-imports-exports": "^0.2.4",
-        "semver": "^7.6.3",
-        "spdx-expression-parse": "^4.0.0"
+        "semver": "^7.8.5",
+        "spdx-expression-parse": "^4.0.0",
+        "to-valid-identifier": "^1.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": "^22.13.0 || >=24"
       },
       "peerDependencies": {
-        "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0"
+        "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0"
       }
     },
     "node_modules/eslint-scope": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
-      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
+        "@types/esrecurse": "^4.3.1",
+        "@types/estree": "^1.0.8",
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -1223,53 +1166,53 @@
       }
     },
     "node_modules/eslint/node_modules/eslint-visitor-keys": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/espree": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
-      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "acorn": "^8.15.0",
+        "acorn": "^8.16.0",
         "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^4.2.1"
+        "eslint-visitor-keys": "^5.0.1"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/espree/node_modules/eslint-visitor-keys": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/esquery": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
-      "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -1378,9 +1321,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.3.tgz",
+      "integrity": "sha512-/zipXxyO6rGvuNGDiULY9MvEGSkb2gaG4GGH4ygMi0ZZzyMHdUZBmntJmx5x1G2VuPytCwGN4xsJP6cw+sK+vQ==",
       "dev": true,
       "license": "ISC"
     },
@@ -1397,28 +1340,22 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/globals": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
-      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+    "node_modules/html-entities": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
+      "integrity": "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==",
       "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/mdevils"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/mdevils"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -1428,23 +1365,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
-      }
-    },
-    "node_modules/import-fresh": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
-      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "parent-module": "^1.0.0",
-        "resolve-from": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/imurmurhash": {
@@ -1487,27 +1407,14 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
     "node_modules/jsdoc-type-pratt-parser": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-4.1.0.tgz",
-      "integrity": "sha512-Hicd6JK5Njt2QB6XYFS7ok9e37O8AYk3jTcppG4YVQnYjOemymvTcmc7OWsmq/Qqj5TdRFO5/x/tIPmBeRtGHg==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-7.2.0.tgz",
+      "integrity": "sha512-dh140MMgjyg3JhJZY/+iEzW+NO5xR2gpbDFKHqotCmexElVntw7GjWjt511+C/Ef02RU5TKYrJo/Xlzk+OLaTw==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/json-buffer": {
@@ -1571,24 +1478,20 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/lodash.merge": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
-        "node": "*"
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/ms": {
@@ -1602,6 +1505,13 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/object-deep-merge": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/object-deep-merge/-/object-deep-merge-2.0.1.tgz",
+      "integrity": "sha512-aKttDKcU3pyZqKcCkDhsMn70WmZFG2JGDQLP9EcLyTSIFQRCPWLAmBZRLJnrVUrhPG1jETEEbfdgbNtJf1LyMg==",
       "dev": true,
       "license": "MIT"
     },
@@ -1653,19 +1563,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/parent-module": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
-      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "callsites": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/parse-imports-exports": {
@@ -1725,20 +1622,23 @@
         "node": ">=6"
       }
     },
-    "node_modules/resolve-from": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+    "node_modules/reserved-identifiers": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/reserved-identifiers/-/reserved-identifiers-1.2.0.tgz",
+      "integrity": "sha512-yE7KUfFvaBFzGPs5H3Ops1RevfUEsDc5Iz65rOwWg4lE8HJSYtle77uul3+573457oHvBKuHYDl/xqUkKpEEdw==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=4"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -1796,30 +1696,21 @@
       "dev": true,
       "license": "CC0-1.0"
     },
-    "node_modules/strip-json-comments": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+    "node_modules/to-valid-identifier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/to-valid-identifier/-/to-valid-identifier-1.0.0.tgz",
+      "integrity": "sha512-41wJyvKep3yT2tyPqX/4blcfybknGB4D+oETKLs7Q76UiPqRpUJK3hr1nxelyYO0PHKVzJwlu0aCeEAsGI6rpw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "has-flag": "^4.0.0"
+        "@sindresorhus/base62": "^1.0.0",
+        "reserved-identifiers": "^1.0.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/type-check": {
@@ -1836,9 +1727,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gnome-shell-extension-audio-switch-shortcuts",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Add keyboard shortcuts to switch audio input and output.",
   "type": "module",
   "private": true,
@@ -16,12 +16,12 @@
   "homepage": "https://github.com/dbatis/gnome-shell-extension-audio-switch-shortcuts",
   "sideEffects": false,
   "devDependencies": {
-    "eslint": "^9.26.0",
-    "eslint-plugin-jsdoc": "^50.6.11",
-    "typescript": "^5.8.3"
+    "eslint": "^10.7.0",
+    "eslint-plugin-jsdoc": "^63.2.0",
+    "typescript": "^6.0.3"
   },
   "dependencies": {
-    "@girs/gjs": "^4.0.0-beta.23",
-    "@girs/gnome-shell": "^48.0.2"
+    "@girs/gjs": "^4.1.0",
+    "@girs/gnome-shell": "^50.0.4"
   }
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,10 @@
+{ pkgs ? import <nixpkgs> { } }:
+
+pkgs.mkShell {
+  nativeBuildInputs = with pkgs; [
+    gnumake
+    glib
+    gettext
+    nodejs
+  ];
+}

--- a/src/deviceSettings.ts
+++ b/src/deviceSettings.ts
@@ -1,22 +1,22 @@
-import Gio from 'gi://Gio'
+import Gio from "gi://Gio";
 
-import * as Constants from './constants.js'
+import * as Constants from "./constants.js";
 
 export enum DeviceType {
-    INPUT = "INPUT",
-    OUTPUT = "OUTPUT",
+  INPUT = "INPUT",
+  OUTPUT = "OUTPUT",
 }
 
 /**
  * Represents an audio device and its cycling status.
  */
 export type StoredDevice = {
-    id: number,
-    name: string,
-    type: DeviceType,
-    cycled: boolean,
-    active: boolean
-}
+  id: number;
+  name: string;
+  type: DeviceType;
+  cycled: boolean;
+  active: boolean;
+};
 
 /**
  * Utility to handle settings for the audio switcher.
@@ -26,147 +26,166 @@ export type StoredDevice = {
  * by extension.ts and prefs.ts.
  */
 export class DeviceSettings {
-    private extensionSettings: Gio.Settings
+  private extensionSettings: Gio.Settings;
 
-    constructor(settings: Gio.Settings) {
-        this.extensionSettings = settings
+  constructor(settings: Gio.Settings) {
+    this.extensionSettings = settings;
+  }
+
+  getActiveDevices(deviceType: DeviceType) {
+    return this.load(deviceType).filter(
+      (d) => d.type === deviceType && d.active,
+    );
+  }
+
+  getCycledDevices(deviceType: DeviceType) {
+    return this.load(deviceType).filter(
+      (d) => d.type === deviceType && d.active && d.cycled,
+    );
+  }
+
+  /**
+   * Should be used only on startup. This will set all devices as disabled. In the next step,
+   * for each active device `addOrEnableDevice` should be called, and then the `postStartup()`
+   * method should be called, which will remove inactive, uncycled devices.
+   */
+  preStartup() {
+    const devices = this.loadAll();
+    for (const device of devices) {
+      device.active = false;
+    }
+    this.store(devices);
+  }
+
+  /**
+   * Remove devices that were not re-activated during startup, and do not participate in
+   * the keyboard shortcut switching devices.
+   */
+  postStartup() {
+    const devices = this.loadAll();
+    const newArray: StoredDevice[] = [];
+    for (const device of devices) {
+      if (device.active || device.cycled) {
+        newArray.push(device);
+      }
+    }
+    this.store(devices);
+  }
+
+  /**
+   * Add a new input device with the given name mark it as cycled: false, active: true.
+   * If the device already exists in settings, update its id and mark it as active.
+   */
+  addOrEnableDevice(name: string, id: number, deviceType: DeviceType) {
+    const devices = this.loadAll();
+    const existingDevice = devices.find(
+      (d) => d.name === name && d.type === deviceType,
+    );
+    if (!existingDevice) {
+      // device not found, append it and store in settings
+      devices.push({
+        id: id,
+        name: name,
+        type: deviceType,
+        cycled: false,
+        active: true,
+      });
+    } else {
+      // this updates the array value as well
+      existingDevice.active = true;
+      existingDevice.id = id;
+    }
+    this.store(devices);
+  }
+
+  disableDevice(name: string, deviceType: DeviceType) {
+    const devices = this.loadAll();
+    const existingDevice = devices.find(
+      (d) => d.name === name && d.type === deviceType,
+    );
+    if (existingDevice) {
+      existingDevice.active = false;
+    }
+    this.store(devices);
+  }
+
+  /**
+   * Update active and cycled fields of device in settings. Does nothing if the device
+   * was not found already in settings.
+   */
+  setCycled(name: string, deviceType: DeviceType, cycled: boolean) {
+    const devices = this.loadAll();
+    const existingDevice = devices.find(
+      (d) => d.name === name && d.type === deviceType,
+    );
+    if (existingDevice) {
+      existingDevice.cycled = cycled;
+      this.store(devices);
+    }
+  }
+
+  /**
+   * Remove the device from its current position, add it in the new position. Should only be used for active devices.
+   *
+   * @param name device to alter.
+   * @param type device type
+   * @param newPosition zero-based index of new position, relative to devices of same type
+   */
+  reorderDevice(name: string, type: DeviceType, newPosition: number) {
+    const devices = this.loadAll();
+
+    // find device. If not found, ignore
+    const device = devices.find((d) => d.name === name && d.type === type);
+    if (!device || !device.active) {
+      // guard against misuse
+      return;
     }
 
-    getActiveDevices(deviceType: DeviceType) {
-        return this.load(deviceType).filter(d => d.type === deviceType && d.active)
-    }
-
-    getCycledDevices(deviceType: DeviceType) {
-        return this.load(deviceType).filter(d => d.type === deviceType && d.active && d.cycled)
-    }
-
-    /**
-     * Should be used only on startup. This will set all devices as disabled. In the next step,
-     * for each active device `addOrEnableDevice` should be called, and then the `postStartup()`
-     * method should be called, which will remove inactive, uncycled devices.
-     */
-    preStartup() {
-        const devices = this.loadAll()
-        for (const device of devices) {
-            device.active = false
+    const newArray: StoredDevice[] = [];
+    let deviceCount = 0;
+    let wasPlacedInLoop = false;
+    for (const storedDevice of devices) {
+      if (
+        storedDevice.name === device.name &&
+        storedDevice.type === device.type
+      ) {
+        continue;
+        // do nothing, we essentially remove it from new array
+      }
+      if (storedDevice.type === device.type && storedDevice.active) {
+        // active device, increase counter and check if we must place the device there
+        deviceCount++;
+        if (!wasPlacedInLoop && deviceCount > newPosition) {
+          newArray.push(device);
+          wasPlacedInLoop = true;
         }
-        this.store(devices)
+      }
+      newArray.push(storedDevice);
     }
 
-    /**
-     * Remove devices that were not re-activated during startup, and do not participate in
-     * the keyboard shortcut switching devices.
-     */
-    postStartup() {
-        const devices = this.loadAll()
-        const newArray: StoredDevice[] = []
-        for (const device of devices) {
-            if (device.active || device.cycled) {
-                newArray.push(device)
-            }
-        }
-        this.store(devices)
+    // if it was not placed in loop, because it will be last item, add it now
+    if (!wasPlacedInLoop) {
+      newArray.push(device);
     }
+    this.store(newArray);
+  }
 
-    /**
-     * Add a new input device with the given name mark it as cycled: false, active: true.
-     * If the device already exists in settings, update its id and mark it as active.
-     */
-     addOrEnableDevice(name: string, id: number, deviceType: DeviceType) {
-        const devices = this.loadAll()
-        const existingDevice = devices.find(d =>
-            d.name === name && d.type === deviceType)
-        if (!existingDevice) {
-            // device not found, append it and store in settings
-            devices.push({id: id, name: name, type: deviceType, cycled: false, active: true})
-        } else {
-            // this updates the array value as well
-            existingDevice.active = true
-            existingDevice.id = id
-        }
-        this.store(devices)
-    }
+  private load(deviceType: DeviceType): StoredDevice[] {
+    return JSON.parse(
+      this.extensionSettings.get_string(Constants.KEY_AUDIO_DEVICES),
+    ).filter((d: StoredDevice) => d.type === deviceType);
+  }
 
-    disableDevice(name: string, deviceType: DeviceType) {
-        const devices = this.loadAll()
-        const existingDevice = devices.find(
-            (d) => d.name === name && d.type === deviceType
-        )
-        if (existingDevice) {
-            existingDevice.active = false
-        }
-        this.store(devices)
-    }
+  private loadAll(): StoredDevice[] {
+    return JSON.parse(
+      this.extensionSettings.get_string(Constants.KEY_AUDIO_DEVICES),
+    );
+  }
 
-    /**
-     * Update active and cycled fields of device in settings. Does nothing if the device
-     * was not found already in settings.
-     */
-    setCycled(name: string, deviceType: DeviceType, cycled: boolean) {
-        const devices = this.loadAll()
-        const existingDevice = devices.find(
-            (d) => d.name === name && d.type === deviceType
-        )
-        if (existingDevice) {
-           existingDevice.cycled = cycled
-           this.store(devices)
-        }
-    }
-
-    /**
-     * Remove the device from its current position, add it in the new position. Should only be used for active devices.
-     *
-     * @param name device to alter.
-     * @param type device type
-     * @param newPosition zero-based index of new position, relative to devices of same type
-     */
-    reorderDevice(name: string, type: DeviceType, newPosition: number) {
-
-        const devices = this.loadAll()
-
-        // find device. If not found, ignore
-        const device = devices.find(d => d.name === name && d.type === type);
-        if (!device || !device.active) {
-            // guard against misuse
-            return
-        }
-
-        const newArray: StoredDevice[] = []
-        let deviceCount = 0
-        let wasPlacedInLoop = false
-        for (const storedDevice of devices) {
-            if (storedDevice.name === device.name && storedDevice.type === device.type) {
-                // do nothing, we essentially remove it from new array
-            } else if (storedDevice.type === device.type && storedDevice.active) {
-                // active device, increase counter and check if we must place the device there
-                deviceCount++
-                if (!wasPlacedInLoop && deviceCount > newPosition) {
-                    newArray.push(device)
-                    wasPlacedInLoop = true
-                }
-                newArray.push(storedDevice)
-            } else {
-                newArray.push(storedDevice)
-            }
-        }
-
-        // if it was not placed in loop, because it will be last item, add it now
-        if (!wasPlacedInLoop) {
-            newArray.push(device)
-        }
-        this.store(newArray)
-    }
-
-    private load(deviceType: DeviceType): StoredDevice[] {
-        return JSON.parse(this.extensionSettings.get_string(Constants.KEY_AUDIO_DEVICES))
-            .filter((d: StoredDevice) => d.type === deviceType)
-    }
-
-    private loadAll(): StoredDevice[] {
-        return JSON.parse(this.extensionSettings.get_string(Constants.KEY_AUDIO_DEVICES))
-    }
-
-    private store(value: StoredDevice[]) {
-        this.extensionSettings.set_string(Constants.KEY_AUDIO_DEVICES, JSON.stringify(value))
-    }
+  private store(value: StoredDevice[]) {
+    this.extensionSettings.set_string(
+      Constants.KEY_AUDIO_DEVICES,
+      JSON.stringify(value),
+    );
+  }
 }

--- a/src/mixer.ts
+++ b/src/mixer.ts
@@ -5,293 +5,321 @@
  * Original code is licensed under the MIT license (https://github.com/marcinjahn/gnome-quicksettings-audio-devices-hider-extension/blob/main/LICENSE)
  */
 
-import Gvc from 'gi://Gvc'
+import Gvc from "gi://Gvc";
 import Gio from "gi://Gio";
-import * as Volume from 'resource:///org/gnome/shell/ui/status/volume.js'
-import * as Main from 'resource:///org/gnome/shell/ui/main.js'
+import * as Volume from "resource:///org/gnome/shell/ui/status/volume.js";
+import * as Main from "resource:///org/gnome/shell/ui/main.js";
 
-import {DeviceType, StoredDevice} from "./deviceSettings.js";
-import {delay, range} from "./utils.js";
+import { DeviceType, StoredDevice } from "./deviceSettings.js";
+import { delay, range } from "./utils.js";
 
 export enum Action {
-    ADDED = "ADDED",
-    REMOVED = "REMOVED"
+  ADDED = "ADDED",
+  REMOVED = "REMOVED",
 }
 
 export interface MixerEvent {
-    type: DeviceType,
-    action: Action,
-    deviceId: number
+  type: DeviceType;
+  action: Action;
+  deviceId: number;
 }
 
 export interface MixerSubscription {
-    ids: number[];
+  ids: number[];
 }
 
 /**
  * Represents the id of a device from MixerControl
  */
 export type MixerDevice = {
-    id: number,
-    name: string
-}
+  id: number;
+  name: string;
+};
 
 export class MixerSource {
-    async getMixer(): Promise<Mixer> {
-        const mixer = Volume.getMixerControl();
+  async getMixer(): Promise<Mixer> {
+    const mixer = Volume.getMixerControl();
 
-        await waitForMixerToBeReady(mixer);
-        await delay(200);
+    await waitForMixerToBeReady(mixer);
+    await delay(200);
 
-        return new Mixer(mixer, () => {});
-    }
+    return new Mixer(mixer, () => {});
+  }
 }
 
-async function waitForMixerToBeReady(
-    mixer: Gvc.MixerControl
-): Promise<void> {
-    while (mixer.get_state() === Gvc.MixerControlState.CONNECTING) {
-        await delay(200);
-    }
+async function waitForMixerToBeReady(mixer: Gvc.MixerControl): Promise<void> {
+  while (mixer.get_state() === Gvc.MixerControlState.CONNECTING) {
+    await delay(200);
+  }
 
-    const state = mixer.get_state();
+  const state = mixer.get_state();
 
-    if (state === Gvc.MixerControlState.FAILED) {
-        throw new Error("MixerControl is in a failed state");
-    } else if (state === Gvc.MixerControlState.CLOSED) {
-        throw new Error("MixerControl is in a closed state");
-    }
+  if (state === Gvc.MixerControlState.FAILED) {
+    throw new Error("MixerControl is in a failed state");
+  } else if (state === Gvc.MixerControlState.CLOSED) {
+    throw new Error("MixerControl is in a closed state");
+  }
 }
 
 export class Mixer {
-    constructor(private control: Gvc.MixerControl, private disposal: () => void) {}
+  constructor(
+    private control: Gvc.MixerControl,
+    private disposal: () => void,
+  ) {}
 
-    getAllDevices(type: DeviceType): MixerDevice[] {
-        const quickSettings = Main.panel.statusArea.quickSettings
-        const devices = type === DeviceType.OUTPUT
-            ? quickSettings._volumeOutput._output._deviceItems
-            : quickSettings._volumeInput._input._deviceItems
-        const ids: number[] = Array.from(devices, ([id]) => id)
-        return this.getAudioDevicesFromIds(ids, type)
+  getAllDevices(type: DeviceType): MixerDevice[] {
+    const quickSettings = Main.panel.statusArea.quickSettings;
+    if (!quickSettings) {
+      return [];
+    }
+    const devices =
+      type === DeviceType.OUTPUT
+        ? quickSettings._volumeOutput?._output._deviceItems
+        : quickSettings._volumeInput?._input._deviceItems;
+    if (!devices) {
+      return [];
+    }
+    const ids: number[] = Array.from(devices, ([id]) => id);
+    return this.getAudioDevicesFromIds(ids, type);
+  }
+
+  /**
+   * Makes a best-effort to get the name of a device from the Quick Settings Audio Panel.
+   *
+   * This method is useful in case the user has an extension like
+   * https://github.com/marcinjahn/gnome-quicksettings-audio-devices-renamer-extension/tree/main
+   * which renames audio devices.
+   *
+   * As other extensions also interfere with how the audio panel works, it is not guaranteed
+   * that any name will be found (for instance, if an extension to hide devices has been used).
+   *
+   * @param device stored device in extension's settings
+   *
+   * @returns device name, if found, or undefined when this did not work
+   */
+  getAudioPanelDeviceName(device: StoredDevice): string | undefined {
+    try {
+      const quickSettings = Main.panel.statusArea.quickSettings;
+      const quickSettingsDevices =
+        device.type === DeviceType.OUTPUT
+          ? quickSettings?._volumeOutput?._output._deviceItems
+          : quickSettings?._volumeInput?._input._deviceItems;
+
+      return quickSettingsDevices?.get(device.id)?.label.get_text();
+    } catch (error) {
+      // another extension may have messed with the audio panel
+      return undefined;
+    }
+  }
+
+  /**
+   * Get the icon for an audio device. If not found, use generic input or output icon.
+   *
+   * Based on code from tumist at
+   * https://github.com/dbatis/gnome-shell-extension-audio-switch-shortcuts/commit/8df9194f823245945ae70abdff4c3964a615238f
+   *
+   * @param device stored device in extension's settings
+   *
+   * @returns device icon , or generic input/output icon
+   */
+  getIcon(device: StoredDevice): Gio.Icon {
+    const mixerDevice = this.getUiDeviceFromStoredDevice(device);
+    const maybeIconName = mixerDevice?.get_icon_name();
+
+    if (!maybeIconName) {
+      // device not found, return generic icon
+      return device.type === DeviceType.OUTPUT
+        ? Gio.ThemedIcon.new_with_default_fallbacks("audio-speakers-symbolic")
+        : Gio.ThemedIcon.new_with_default_fallbacks(
+            "audio-input-microphone-symbolic",
+          );
+    } else {
+      return Gio.ThemedIcon.new_with_default_fallbacks(
+        maybeIconName + "-symbolic",
+      );
+    }
+  }
+
+  /**
+   * Get volume level for an audio device, as a ratio to max volume.
+   *
+   * Based on code from tumist at
+   * https://github.com/dbatis/gnome-shell-extension-audio-switch-shortcuts/commit/8df9194f823245945ae70abdff4c3964a615238f
+   *
+   * @param device stored device in extension's settings
+   *
+   * @returns volume level, or undefined if device not found
+   * */
+  getVolume(device: StoredDevice): number | undefined {
+    const mixerDevice = this.getUiDeviceFromStoredDevice(device);
+
+    if (!mixerDevice) {
+      return undefined;
+    } else {
+      const stream = this.control.get_stream_from_device(mixerDevice);
+      return stream.get_volume() / this.control.get_vol_max_norm();
+    }
+  }
+
+  /**
+   * Generate a name similar to https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/status/volume.js#L132
+   *
+   * @param device Gvc lookup value
+   * @private
+   */
+  private constructDeviceName(device: Gvc.MixerUIDevice) {
+    return device.origin
+      ? `${device.description} - ${device.origin}`
+      : device.description;
+  }
+
+  getAudioDevicesFromIds(ids: number[], type: DeviceType): MixerDevice[] {
+    return this.getUIDevicesFromIds(ids, type).map((device) => {
+      return { id: device.get_id(), name: this.constructDeviceName(device) };
+    });
+  }
+
+  /**
+   * Convert a settings-stored device to Gvc mixer device.
+   *
+   * @param device stored device in extension's settings
+   *
+   * @returns mixer device, if found, null otherwise
+   *
+   * @private
+   */
+  private getUiDeviceFromStoredDevice(
+    device: StoredDevice,
+  ): Gvc.MixerUIDevice | null {
+    return device.type === DeviceType.OUTPUT
+      ? this.control.lookup_output_id(device.id)
+      : this.control.lookup_input_id(device.id);
+  }
+
+  private getUIDevicesFromIds(
+    ids: number[],
+    type: DeviceType,
+  ): Gvc.MixerUIDevice[] {
+    return ids.map((id) => {
+      const lookup =
+        type === DeviceType.OUTPUT
+          ? this.control.lookup_output_id(id)
+          : this.control.lookup_input_id(id);
+
+      return lookup;
+    });
+  }
+
+  getDefaultOutput(): string {
+    const stream = this.control.get_default_sink();
+    return this.constructDeviceName(
+      this.control.lookup_device_from_stream(stream),
+    );
+  }
+
+  getDefaultInput(): string {
+    const stream = this.control.get_default_source();
+    return this.constructDeviceName(
+      this.control.lookup_device_from_stream(stream),
+    );
+  }
+
+  /**
+   * Set output device. First, try by id. If id not found, try finding it with name.
+   *
+   * @param id device id
+   * @param name display name
+   * @returns true if device changed, false if no device found with this name
+   */
+  setOutput(id: number, name: string): boolean {
+    let device = this.control.lookup_output_id(id);
+    if (!device) {
+      const deviceByName = this.getDeviceFromName(name, DeviceType.OUTPUT);
+      if (deviceByName) {
+        device = deviceByName;
+      }
     }
 
-    /**
-     * Makes a best-effort to get the name of a device from the Quick Settings Audio Panel.
-     *
-     * This method is useful in case the user has an extension like
-     * https://github.com/marcinjahn/gnome-quicksettings-audio-devices-renamer-extension/tree/main
-     * which renames audio devices.
-     *
-     * As other extensions also interfere with how the audio panel works, it is not guaranteed
-     * that any name will be found (for instance, if an extension to hide devices has been used).
-     *
-     * @param device stored device in extension's settings
-     *
-     * @returns device name, if found, or undefined when this did not work
-     */
-    getAudioPanelDeviceName(device: StoredDevice): string | undefined {
-        try {
-            const quickSettings = Main.panel.statusArea.quickSettings
-            const quickSettingsDevices = device.type === DeviceType.OUTPUT
-                ? quickSettings._volumeOutput._output._deviceItems
-                : quickSettings._volumeInput._input._deviceItems
+    if (device) {
+      this.control.change_output(device);
+      return true;
+    } else {
+      return false;
+    }
+  }
 
-            return quickSettingsDevices.get(device.id)?.label.get_text()
-
-        } catch (error) {
-            // another extension may have messed with the audio panel
-            return undefined
-        }
+  /**
+   * Set input device. First, try by id. If id not found, try finding it with name.
+   *
+   * @param id device id
+   * @param name display name
+   * @returns true if device changed, false if no device found with this name
+   */
+  setInput(id: number, name: string): boolean {
+    let device = this.control.lookup_input_id(id);
+    if (!device) {
+      const deviceByName = this.getDeviceFromName(name, DeviceType.INPUT);
+      if (deviceByName) {
+        device = deviceByName;
+      }
     }
 
-    /**
-     * Get the icon for an audio device. If not found, use generic input or output icon.
-     *
-     * Based on code from tumist at
-     * https://github.com/dbatis/gnome-shell-extension-audio-switch-shortcuts/commit/8df9194f823245945ae70abdff4c3964a615238f
-     *
-     * @param device stored device in extension's settings
-     *
-     * @returns device icon , or generic input/output icon
-     */
-    getIcon(device: StoredDevice): Gio.Icon {
-        const mixerDevice = this.getUiDeviceFromStoredDevice(device)
-        const maybeIconName = mixerDevice?.get_icon_name()
-
-        if (!maybeIconName) {
-            // device not found, return generic icon
-            return device.type === DeviceType.OUTPUT
-                   ? Gio.ThemedIcon.new_with_default_fallbacks("audio-speakers-symbolic")
-                   : Gio.ThemedIcon.new_with_default_fallbacks("audio-input-microphone-symbolic")
-        } else {
-            return Gio.ThemedIcon.new_with_default_fallbacks(maybeIconName + "-symbolic")
-        }
-
+    if (device) {
+      this.control.change_input(device);
+      return true;
+    } else {
+      return false;
     }
+  }
 
-    /**
-     * Get volume level for an audio device, as a ratio to max volume.
-     *
-     * Based on code from tumist at
-     * https://github.com/dbatis/gnome-shell-extension-audio-switch-shortcuts/commit/8df9194f823245945ae70abdff4c3964a615238f
-     *
-     * @param device stored device in extension's settings
-     *
-     * @returns volume level, or undefined if device not found
-     * */
-    getVolume(device: StoredDevice): number | undefined {
-        const mixerDevice = this.getUiDeviceFromStoredDevice(device)
+  /**
+   * Uses a Dummy Device "trick" from
+   * https://github.com/kgshank/gse-sound-output-device-chooser/blob/master/sound-output-device-chooser@kgshank.net/base.js#LL299C20-L299C20
+   * @param name display name
+   * @param type device type
+   * @returns mixer stream
+   */
+  private getDeviceFromName(
+    name: string,
+    type: DeviceType,
+  ): Gvc.MixerUIDevice | undefined {
+    const dummyDevice = new Gvc.MixerUIDevice();
+    const devices = this.getUIDevicesFromIds(range(dummyDevice.get_id()), type);
+    console.info(devices);
 
-        if (!mixerDevice) {
-            return undefined
-        } else {
-            const stream = this.control.get_stream_from_device(mixerDevice)
-            return stream.get_volume() / this.control.get_vol_max_norm()
-        }
-    }
+    return devices.find(
+      (d) => d !== null && this.constructDeviceName(d) === name,
+    );
+  }
 
-    /**
-     * Generate a name similar to https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/status/volume.js#L132
-     *
-     * @param device Gvc lookup value
-     * @private
-     */
-    private constructDeviceName(device: Gvc.MixerUIDevice) {
-        return device.origin ? `${device.description} - ${device.origin}` : device.description
-    }
+  subscribeToDeviceChanges(
+    callback: (event: MixerEvent) => void,
+  ): MixerSubscription {
+    const addOutputId = this.control.connect("output-added", (_, deviceId) =>
+      callback({ deviceId, type: DeviceType.OUTPUT, action: Action.ADDED }),
+    );
+    const removeOutputId = this.control.connect(
+      "output-removed",
+      (_, deviceId) =>
+        callback({ deviceId, type: DeviceType.OUTPUT, action: Action.REMOVED }),
+    );
+    const addInputId = this.control.connect("input-added", (_, deviceId) =>
+      callback({ deviceId, type: DeviceType.INPUT, action: Action.ADDED }),
+    );
+    const removeInputId = this.control.connect("input-removed", (_, deviceId) =>
+      callback({ deviceId, type: DeviceType.INPUT, action: Action.REMOVED }),
+    );
 
-    getAudioDevicesFromIds(ids: number[], type: DeviceType): MixerDevice[] {
-        return this.getUIDevicesFromIds(ids, type).map(device => {
-            return { id: device.get_id(), name: this.constructDeviceName(device) }
-        })
-    }
+    return { ids: [addOutputId, removeOutputId, addInputId, removeInputId] };
+  }
 
-    /**
-     * Convert a settings-stored device to Gvc mixer device.
-     *
-     * @param device stored device in extension's settings
-     *
-     * @returns mixer device, if found, null otherwise
-     *
-     * @private
-     */
-    private getUiDeviceFromStoredDevice(device: StoredDevice): Gvc.MixerUIDevice | null {
-        return device.type === DeviceType.OUTPUT
-            ? this.control.lookup_output_id(device.id)
-            : this.control.lookup_input_id(device.id)
-    }
+  unsubscribe(subscription: MixerSubscription) {
+    subscription.ids.forEach((id) => {
+      this.control.disconnect(id);
+    });
+  }
 
-    private getUIDevicesFromIds(ids: number[], type: DeviceType): Gvc.MixerUIDevice[] {
-        return ids.map((id) => {
-            const lookup = type === DeviceType.OUTPUT
-                ? this.control.lookup_output_id(id)
-                : this.control.lookup_input_id(id);
-
-            return lookup
-        });
-
-    }
-
-    getDefaultOutput(): string {
-        const stream = this.control.get_default_sink()
-        return this.constructDeviceName(this.control.lookup_device_from_stream(stream))
-    }
-
-    getDefaultInput(): string {
-        const stream = this.control.get_default_source()
-        return this.constructDeviceName(this.control.lookup_device_from_stream(stream))
-    }
-
-    /**
-     * Set output device. First, try by id. If id not found, try finding it with name.
-     *
-     * @param id device id
-     * @param name display name
-     * @returns true if device changed, false if no device found with this name
-     */
-    setOutput(id: number, name: string): boolean {
-        let device = this.control.lookup_output_id(id);
-        if (!device) {
-            const deviceByName = this.getDeviceFromName(name, DeviceType.OUTPUT)
-            if (deviceByName) {
-                device = deviceByName
-            }
-        }
-
-        if (device) {
-            this.control.change_output(device)
-            return true
-        } else {
-            return false
-        }
-    }
-
-    /**
-     * Set input device. First, try by id. If id not found, try finding it with name.
-     *
-     * @param id device id
-     * @param name display name
-     * @returns true if device changed, false if no device found with this name
-     */
-    setInput(id: number, name: string): boolean {
-        let device = this.control.lookup_input_id(id);
-        if (!device) {
-            const deviceByName = this.getDeviceFromName(name, DeviceType.INPUT)
-            if (deviceByName) {
-                device = deviceByName
-            }
-        }
-
-        if (device) {
-            this.control.change_input(device)
-            return true
-        } else {
-            return false
-        }
-    }
-
-    /**
-     * Uses a Dummy Device "trick" from
-     * https://github.com/kgshank/gse-sound-output-device-chooser/blob/master/sound-output-device-chooser@kgshank.net/base.js#LL299C20-L299C20
-     * @param name display name
-     * @param type device type
-     * @returns mixer stream
-     */
-    private getDeviceFromName(name: string, type: DeviceType): Gvc.MixerUIDevice | undefined {
-        const dummyDevice = new Gvc.MixerUIDevice();
-        const devices = this.getUIDevicesFromIds(range(dummyDevice.get_id()), type)
-        console.info(devices)
-
-        return devices.find(d => d !== null && this.constructDeviceName(d) === name)
-    }
-
-    subscribeToDeviceChanges(
-        callback: (event: MixerEvent) => void
-    ): MixerSubscription {
-        const addOutputId = this.control.connect("output-added", (_, deviceId) =>
-            callback({ deviceId, type: DeviceType.OUTPUT, action: Action.ADDED })
-        );
-        const removeOutputId = this.control.connect("output-removed", (_, deviceId) =>
-            callback({ deviceId, type: DeviceType.OUTPUT, action: Action.REMOVED })
-        );
-        const addInputId = this.control.connect("input-added", (_, deviceId) =>
-            callback({ deviceId, type: DeviceType.INPUT, action: Action.ADDED })
-        );
-        const removeInputId = this.control.connect("input-removed", (_, deviceId) =>
-            callback({ deviceId, type: DeviceType.INPUT, action: Action.REMOVED })
-        );
-
-        return { ids: [addOutputId, removeOutputId, addInputId, removeInputId] };
-    }
-
-    unsubscribe(subscription: MixerSubscription) {
-        subscription.ids.forEach((id) => {
-            this.control.disconnect(id);
-        });
-    }
-
-    dispose() {
-        this.disposal();
-    }
-
+  dispose() {
+    this.disposal();
+  }
 }

--- a/src/prefs.ts
+++ b/src/prefs.ts
@@ -1,240 +1,285 @@
-import Gio from 'gi://Gio'
-import Adw from 'gi://Adw'
-import Gtk from 'gi://Gtk'
+import Gio from "gi://Gio";
+import Adw from "gi://Adw";
+import Gtk from "gi://Gtk";
 import Gdk from "gi://Gdk";
 import GObject from "gi://GObject";
 
-import {ExtensionPreferences, gettext as _} from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js'
+import {
+  ExtensionPreferences,
+  gettext as _,
+} from "resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js";
 
-import * as Constants from './constants.js'
-import {DeviceSettings, DeviceType} from "./deviceSettings.js";
-import {buildShortcutButtonRow} from "./keymapButton.js";
-import BindingFlags = GObject.BindingFlags;
+import * as Constants from "./constants.js";
+import { DeviceSettings, DeviceType } from "./deviceSettings.js";
+import { buildShortcutButtonRow } from "./keymapButton.js";
 
 export default class AudioSwitchShortcutsPreferences extends ExtensionPreferences {
+  fillPreferencesWindow(window: Adw.PreferencesWindow): Promise<void> {
+    const extensionSettings = this.getSettings();
+    const deviceSettings = new DeviceSettings(extensionSettings);
 
-    fillPreferencesWindow(window: Adw.PreferencesWindow): Promise<void> {
-        const extensionSettings = this.getSettings()
-        const deviceSettings = new DeviceSettings(extensionSettings)
+    window.add(this.outputPage(extensionSettings, deviceSettings));
+    window.add(this.inputPage(extensionSettings, deviceSettings));
+    window.add(this.miscPage(extensionSettings));
 
-        window.add(this.outputPage(extensionSettings, deviceSettings))
-        window.add(this.inputPage(extensionSettings, deviceSettings))
-        window.add(this.miscPage(extensionSettings))
+    return Promise.resolve();
+  }
 
-        return Promise.resolve()
-    }
+  outputPage(
+    extensionSettings: Gio.Settings,
+    deviceSettings: DeviceSettings,
+  ): Adw.PreferencesPage {
+    const page = new Adw.PreferencesPage({
+      title: _("Audio Outputs"),
+      icon_name: "audio-speakers-symbolic",
+    });
 
-    outputPage(extensionSettings: Gio.Settings, deviceSettings: DeviceSettings): Adw.PreferencesPage {
+    const shortcutGroup = new Adw.PreferencesGroup({
+      title: _("Audio Output Shortcuts"),
+    });
+    page.add(shortcutGroup);
 
-        const page = new Adw.PreferencesPage({
-            title: _('Audio Outputs'),
-            icon_name: 'audio-speakers-symbolic',
-        })
+    const keyboardRow = buildShortcutButtonRow(
+      Constants.KEY_OUTPUT_HOTKEY,
+      extensionSettings,
+      _("Keyboard shortcut"),
+      _("Switch to next audio output device"),
+    );
+    shortcutGroup.add(keyboardRow);
 
-        const shortcutGroup = new Adw.PreferencesGroup({
-            title: _('Audio Output Shortcuts')
-        })
-        page.add(shortcutGroup)
+    const devicesGroup = new Adw.PreferencesGroup({
+      title: _("Audio Devices"),
+      description: _(
+        "Select the devices to cycle through when the keyboard shortcut is pressed. Drag them to set the order.",
+      ),
+    });
+    page.add(devicesGroup);
 
-        const keyboardRow = buildShortcutButtonRow(
-            Constants.KEY_OUTPUT_HOTKEY,
-            extensionSettings,
-            _('Keyboard shortcut'),
-            _('Switch to next audio output device'),
+    const listBox = new Gtk.ListBox({ css_classes: ["boxed-list"] });
+    devicesGroup.add(listBox);
+
+    this.createDeviceList(listBox, deviceSettings, DeviceType.OUTPUT);
+
+    return page;
+  }
+
+  inputPage(
+    extensionSettings: Gio.Settings,
+    deviceSettings: DeviceSettings,
+  ): Adw.PreferencesPage {
+    const page = new Adw.PreferencesPage({
+      title: _("Audio Inputs"),
+      icon_name: "audio-input-microphone-symbolic",
+    });
+
+    const shortcutGroup = new Adw.PreferencesGroup({
+      title: _("Audio Input Shortcuts"),
+    });
+    page.add(shortcutGroup);
+
+    const keyboardRow = buildShortcutButtonRow(
+      Constants.KEY_INPUT_HOTKEY,
+      extensionSettings,
+      _("Keyboard shortcut"),
+      _("Switch to next audio input device"),
+    );
+    shortcutGroup.add(keyboardRow);
+
+    const devicesGroup = new Adw.PreferencesGroup({
+      title: _("Audio Devices"),
+      description: _(
+        "Select the devices to cycle through when the keyboard shortcut is pressed. Drag them to set the order.",
+      ),
+    });
+    page.add(devicesGroup);
+
+    const listBox = new Gtk.ListBox({ css_classes: ["boxed-list"] });
+    devicesGroup.add(listBox);
+
+    this.createDeviceList(listBox, deviceSettings, DeviceType.INPUT);
+
+    return page;
+  }
+
+  private createDeviceList(
+    group: Gtk.ListBox,
+    deviceSettings: DeviceSettings,
+    deviceType: DeviceType,
+  ) {
+    const rowList: Adw.SwitchRow[] = []; // used later on for drag-and-drop
+
+    deviceSettings.getActiveDevices(deviceType).forEach((device) => {
+      const row = new Adw.SwitchRow({
+        title: device.name,
+        active: device.cycled,
+      });
+      row.add_prefix(
+        new Gtk.Image({
+          icon_name: "list-drag-handle-symbolic",
+          css_classes: ["dim-label"],
+        }),
+      );
+      row.connect("notify::active", (source) => {
+        deviceSettings.setCycled(device.name, device.type, source.get_active());
+      });
+
+      group.append(row);
+      rowList.push(row);
+    });
+
+    // add drag-and-drop capability, code based on GNOME Workbench example
+    const dropTarget = Gtk.DropTarget.new(
+      Gtk.ListBoxRow.$gtype,
+      Gdk.DragAction.MOVE,
+    );
+    group.add_controller(dropTarget);
+
+    // Drag:
+    for (const row of rowList) {
+      let drag_x: number;
+      let drag_y: number;
+
+      const dropController = new Gtk.DropControllerMotion();
+
+      const dragSource = new Gtk.DragSource({
+        actions: Gdk.DragAction.MOVE,
+      });
+
+      row.add_controller(dragSource);
+      row.add_controller(dropController);
+
+      dragSource.connect("prepare", (_source, x, y) => {
+        drag_x = x;
+        drag_y = y;
+
+        const value = new GObject.Value();
+        value.init(Gtk.ListBoxRow.$gtype);
+        value.set_object(row);
+
+        return Gdk.ContentProvider.new_for_value(value);
+      });
+
+      dragSource.connect("drag-begin", (_source, drag) => {
+        const dragWidget = new Gtk.ListBox();
+        dragWidget.set_size_request(row.get_width(), row.get_height());
+        dragWidget.add_css_class("boxed-list");
+
+        const dragRow = new Adw.SwitchRow({
+          title: row.title,
+          active: row.active,
+        });
+        dragRow.add_prefix(
+          new Gtk.Image({
+            iconName: "list-drag-handle-symbolic",
+            css_classes: ["dim-label"],
+          }),
         );
-        shortcutGroup.add(keyboardRow)
+        dragWidget.append(dragRow);
+        dragWidget.drag_highlight_row(dragRow);
 
-        const devicesGroup = new Adw.PreferencesGroup({
-            title: _('Audio Devices'),
-            description: _('Select the devices to cycle through when the keyboard shortcut is pressed. Drag them to set the order.')
-        })
-        page.add(devicesGroup)
+        const icon = Gtk.DragIcon.get_for_drag(drag);
+        icon.child = dragWidget;
 
-        const listBox = new Gtk.ListBox({css_classes: ['boxed-list']})
-        devicesGroup.add(listBox)
+        drag.set_hotspot(drag_x, drag_y);
+      });
 
-        this.createDeviceList(listBox, deviceSettings, DeviceType.OUTPUT)
+      dropController.connect("enter", () => {
+        group.drag_highlight_row(row);
+      });
 
-        return page
-    }
-    
-    inputPage(extensionSettings: Gio.Settings, deviceSettings: DeviceSettings): Adw.PreferencesPage {
-
-        const page = new Adw.PreferencesPage({
-            title: _('Audio Inputs'),
-            icon_name: 'audio-input-microphone-symbolic',
-        })
-
-        const shortcutGroup = new Adw.PreferencesGroup({
-            title: _('Audio Input Shortcuts')
-        })
-        page.add(shortcutGroup)
-
-        const keyboardRow = buildShortcutButtonRow(
-            Constants.KEY_INPUT_HOTKEY,
-            extensionSettings,
-            _('Keyboard shortcut'),
-            _('Switch to next audio input device'),
-        );
-        shortcutGroup.add(keyboardRow)
-
-        const devicesGroup = new Adw.PreferencesGroup({
-            title: _('Audio Devices'),
-            description: _('Select the devices to cycle through when the keyboard shortcut is pressed. Drag them to set the order.')
-        })
-        page.add(devicesGroup)
-
-        const listBox = new Gtk.ListBox({css_classes: ['boxed-list']})
-        devicesGroup.add(listBox)
-
-        this.createDeviceList(listBox, deviceSettings, DeviceType.INPUT)
-
-        return page
+      dropController.connect("leave", () => {
+        group.drag_unhighlight_row();
+      });
     }
 
-    private createDeviceList(group: Gtk.ListBox, deviceSettings: DeviceSettings, deviceType: DeviceType) {
+    // Drop:
+    dropTarget.connect("drop", (_drop, value: Adw.SwitchRow, _x, y) => {
+      const targetRow = group.get_row_at_y(y);
+      const targetIndex = targetRow?.get_index();
 
-        const rowList: Adw.SwitchRow[] = [] // used later on for drag-and-drop
+      if (value && targetRow) {
+        group.remove(value);
+        group.insert(value, targetIndex!);
+        targetRow.set_state_flags(Gtk.StateFlags.NORMAL, true);
+        deviceSettings.reorderDevice(value.title, deviceType, targetIndex!);
+        return true;
+      } else {
+        return false;
+      }
+    });
+  }
 
-        deviceSettings.getActiveDevices(deviceType).forEach(device => {
-            const row = new Adw.SwitchRow({
-                title: device.name,
-                active: device.cycled
-            })
-            row.add_prefix(new Gtk.Image({
-                icon_name: 'list-drag-handle-symbolic',
-                css_classes: ['dim-label']
-            }))
-            row.connect('notify::active', source => {
-                deviceSettings.setCycled(device.name, device.type, source.get_active())
-            })
+  miscPage(extensionSettings: Gio.Settings): Adw.PreferencesPage {
+    const page = new Adw.PreferencesPage({
+      title: _("Settings"),
+      icon_name: "applications-system-symbolic",
+    });
 
-            group.append(row)
-            rowList.push(row)
-        })
+    const group = new Adw.PreferencesGroup({
+      title: _("Appearance"),
+      description: _("Configure the appearance of this extension"),
+    });
+    page.add(group);
 
-        // add drag-and-drop capability, code based on GNOME Workbench example
-        const dropTarget = Gtk.DropTarget.new(Gtk.ListBoxRow.$gtype, Gdk.DragAction.MOVE);
-        group.add_controller(dropTarget)
+    // Create a new preferences row
+    const indicator = new Adw.SwitchRow({
+      title: _("Show Indicator"),
+      subtitle: _("Show a tray icon, to get to settings quicker"),
+    });
+    group.add(indicator);
 
-        // Drag:
-        for (const row of rowList) {
-            let drag_x: number
-            let drag_y: number
+    const notifications = new Adw.SwitchRow({
+      title: _("Show Notifications"),
+      subtitle: _("Display a notification message when you press a shortcut"),
+    });
+    group.add(notifications);
 
-            const dropController = new Gtk.DropControllerMotion()
+    const osd = new Adw.SwitchRow({
+      title: _("Use Volume OSD for notifications"),
+      subtitle: _(
+        "Instead of the notification area, use the volume on-screen display area when switching devices.",
+      ),
+    });
+    notifications.bind_property("active", osd, "sensitive", GObject.BindingFlags.DEFAULT);
+    group.add(osd);
 
-            const dragSource = new Gtk.DragSource({
-                actions: Gdk.DragAction.MOVE
-            })
+    const audio = new Adw.SwitchRow({
+      title: _("Play sound on device change"),
+      subtitle: _("Play an audible alert when switching devices"),
+    });
+    group.add(audio);
 
-            row.add_controller(dragSource)
-            row.add_controller(dropController)
+    extensionSettings!.bind(
+      Constants.KEY_INDICATOR,
+      indicator,
+      "active",
+      Gio.SettingsBindFlags.DEFAULT,
+    );
+    extensionSettings!.bind(
+      Constants.KEY_NOTIFICATIONS,
+      notifications,
+      "active",
+      Gio.SettingsBindFlags.DEFAULT,
+    );
+    extensionSettings!.bind(
+      Constants.KEY_SHOW_VOLUME_OSD,
+      osd,
+      "active",
+      Gio.SettingsBindFlags.DEFAULT,
+    );
+    extensionSettings!.bind(
+      Constants.KEY_PLAY_AUDIO_ALERT,
+      audio,
+      "active",
+      Gio.SettingsBindFlags.DEFAULT,
+    );
 
-            dragSource.connect('prepare', (_source, x, y) => {
-                drag_x = x
-                drag_y = y
+    // enable/disable OSD setting. This line needs to be here after bindings,
+    // else it will not initialise properly when dialog first appears.
+    osd.set_sensitive(
+      extensionSettings.get_boolean(Constants.KEY_NOTIFICATIONS),
+    );
 
-                const value = new GObject.Value()
-                value.init(Gtk.ListBoxRow.$gtype)
-                value.set_object(row)
-
-                return Gdk.ContentProvider.new_for_value(value)
-            })
-
-            dragSource.connect('drag-begin', (_source, drag) => {
-                const dragWidget = new Gtk.ListBox
-                dragWidget.set_size_request(row.get_width(), row.get_height())
-                dragWidget.add_css_class('boxed-list')
-
-                const dragRow = new Adw.SwitchRow({title: row.title, active: row.active})
-                dragRow.add_prefix(
-                    new Gtk.Image({iconName: 'list-drag-handle-symbolic', css_classes: ['dim-label']})
-                )
-                dragWidget.append(dragRow)
-                dragWidget.drag_highlight_row(dragRow)
-
-                const icon = Gtk.DragIcon.get_for_drag(drag)
-                icon.child = dragWidget
-
-                drag.set_hotspot(drag_x, drag_y)
-            })
-
-            dropController.connect("enter", () => {
-                group.drag_highlight_row(row);
-            });
-
-            dropController.connect("leave", () => {
-                group.drag_unhighlight_row();
-            });
-        }
-
-        // Drop:
-        dropTarget.connect('drop', (_drop, value: Adw.SwitchRow, _x, y) => {
-            const targetRow = group.get_row_at_y(y)
-            const targetIndex = targetRow?.get_index()
-
-            if (value && targetRow ) {
-                group.remove(value)
-                group.insert(value, targetIndex!)
-                targetRow.set_state_flags(Gtk.StateFlags.NORMAL, true)
-                deviceSettings.reorderDevice(value.title, deviceType, targetIndex!)
-                return true
-            } else {
-                return false
-            }
-        })
-
-    }
-
-    miscPage(extensionSettings: Gio.Settings): Adw.PreferencesPage {
-        const page = new Adw.PreferencesPage({
-            title: _('Settings'),
-            icon_name: 'applications-system-symbolic',
-        })
-
-        const group = new Adw.PreferencesGroup({
-            title: _('Appearance'),
-            description: _('Configure the appearance of this extension'),
-        })
-        page.add(group)
-
-        // Create a new preferences row
-        const indicator = new Adw.SwitchRow({
-            title: _('Show Indicator'),
-            subtitle: _('Show a tray icon, to get to settings quicker'),
-        })
-        group.add(indicator)
-
-        const notifications = new Adw.SwitchRow({
-            title: _('Show Notifications'),
-            subtitle: _('Display a notification message when you press a shortcut'),
-        })
-        group.add(notifications)
-
-        const osd = new Adw.SwitchRow({
-            title: _('Use Volume OSD for notifications'),
-            subtitle: _('Instead of the notification area, use the volume on-screen display area when switching devices.'),
-        })
-        notifications.bind_property('active', osd, 'sensitive', null)
-        group.add(osd)
-
-        const audio = new Adw.SwitchRow({
-            title: _('Play sound on device change'),
-            subtitle: _('Play an audible alert when switching devices')
-        })
-        group.add(audio)
-
-        extensionSettings!.bind(Constants.KEY_INDICATOR, indicator, 'active', Gio.SettingsBindFlags.DEFAULT)
-        extensionSettings!.bind(Constants.KEY_NOTIFICATIONS, notifications, 'active', Gio.SettingsBindFlags.DEFAULT)
-        extensionSettings!.bind(Constants.KEY_SHOW_VOLUME_OSD, osd, 'active', Gio.SettingsBindFlags.DEFAULT)
-        extensionSettings!.bind(Constants.KEY_PLAY_AUDIO_ALERT, audio, 'active', Gio.SettingsBindFlags.DEFAULT)
-
-        // enable/disable OSD setting. This line needs to be here after bindings,
-        // else it will not initialise properly when dialog first appears.
-        osd.set_sensitive(extensionSettings.get_boolean(Constants.KEY_NOTIFICATIONS))
-
-        return page
-    }
-    
+    return page;
+  }
 }

--- a/translations/audio-switch-shortcuts.pot
+++ b/translations/audio-switch-shortcuts.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-14 18:20+0300\n"
+"POT-Creation-Date: 2026-07-22 19:05+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -79,48 +79,48 @@ msgstr ""
 msgid "Switch to next audio input device"
 msgstr ""
 
-#: dist/prefs.js:136
+#: dist/prefs.js:142
 msgid "Settings"
 msgstr ""
 
-#: dist/prefs.js:140
+#: dist/prefs.js:146
 msgid "Appearance"
 msgstr ""
 
-#: dist/prefs.js:141
+#: dist/prefs.js:147
 msgid "Configure the appearance of this extension"
 msgstr ""
 
-#: dist/prefs.js:146
+#: dist/prefs.js:152
 msgid "Show Indicator"
 msgstr ""
 
-#: dist/prefs.js:147
+#: dist/prefs.js:153
 msgid "Show a tray icon, to get to settings quicker"
 msgstr ""
 
-#: dist/prefs.js:151
+#: dist/prefs.js:157
 msgid "Show Notifications"
 msgstr ""
 
-#: dist/prefs.js:152
+#: dist/prefs.js:158
 msgid "Display a notification message when you press a shortcut"
 msgstr ""
 
-#: dist/prefs.js:156
+#: dist/prefs.js:162
 msgid "Use Volume OSD for notifications"
 msgstr ""
 
-#: dist/prefs.js:157
+#: dist/prefs.js:163
 msgid ""
 "Instead of the notification area, use the volume on-screen display area when "
 "switching devices."
 msgstr ""
 
-#: dist/prefs.js:162
+#: dist/prefs.js:168
 msgid "Play sound on device change"
 msgstr ""
 
-#: dist/prefs.js:163
+#: dist/prefs.js:169
 msgid "Play an audible alert when switching devices"
 msgstr ""

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "outDir": "./dist",
+    "rootDir": "./src",
     "sourceMap": false,
     "strict": true,
     "target": "ES2022",


### PR DESCRIPTION
Fixes a startup crash on GNOME 50 and gets the build working again withmodern tooling.

- fix `getAllDevices` returning early when 0 settings/devices found
  (GNOME 50 startup crash)
- fix TypeScript 6 build (explicit `rootDir` in tsconfig)
- light refactor in prefs, bump package deps
- add `shell.nix` for NixOS contributors
- new version 1.1.0
